### PR TITLE
Use onedr0p home-assistant because it doesn't use S6 overlay

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/config/values.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/config/values.yaml
@@ -8,7 +8,7 @@ controllers:
     containers:
       app:
         image:
-          repository: ghcr.io/home-assistant/home-assistant
+          repository: ghcr.io/onedr0p/home-assistant
           pullPolicy: IfNotPresent
           # renovate: datasource=docker depName=homeassistant/home-assistant
           tag: 2024.3.3


### PR DESCRIPTION
Signed-off-by: Dan Webb <dan.webb@damacus.io>
