### PR TITLE
Remove renovate annotations where they're picking the right thing

### DIFF
--- a/kubernetes/apps/home-automation/codeserver/app/config/values.yaml
+++ b/kubernetes/apps/home-automation/codeserver/app/config/values.yaml
@@ -8,7 +8,6 @@ controllers:
       app:
         image:
           repository: ghcr.io/coder/code-server
-          # renovate: datasource=github-releases depName=coder/code-server
           tag: 4.22.1
         args:
           - --auth

--- a/kubernetes/apps/home-automation/home-assistant/app/config/values.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/config/values.yaml
@@ -10,7 +10,6 @@ controllers:
         image:
           repository: ghcr.io/onedr0p/home-assistant
           pullPolicy: IfNotPresent
-          # renovate: datasource=docker depName=homeassistant/home-assistant
           tag: 2024.4.0
 
         env:


### PR DESCRIPTION
I hate home-assisant configured to pick the home-assisant core release,
but I actually needed the onedr0p container. It found both, because of
config

Signed-off-by: Dan Webb <dan.webb@damacus.io>
