### PR TITLE
Fix HASS PVC

### DIFF
--- a/kubernetes/apps/home-automation/config-pvc.yaml
+++ b/kubernetes/apps/home-automation/config-pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: home-assistant-config
+  namespace: home-automation
 spec:
   accessModes:
     - ReadWriteMany


### PR DESCRIPTION
Should fix:
PersistentVolumeClaim/home-assistant-config namespace not specified: the server could not find the requested resource

Signed-off-by: Dan Webb <dan.webb@damacus.io>
