### PR TITLE
[home-assistant-db] Reduce CPU limit

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
@@ -47,7 +47,7 @@ spec:
       memory: 400Mi
     limits:
       memory: 2Gi
-      # cpu: 1000m
+      cpu: 500m
 
   backup:
     retentionPolicy: 30d


### PR DESCRIPTION
Even when restoring databases, we spiked at 0.57

Signed-off-by: Dan Webb <dan.webb@damacus.io>
