### PR TITLE
fix: Add BGP routing policy & reorganise Cilium values

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -1,14 +1,21 @@
 ---
 autoDirectNodeRoutes: true
+
 bandwidthManager:
-  enabled: true
   bbr: true
+  enabled: true
+
 bpf:
   masquerade: true
 
 cluster:
-  name: ironstone
   id: 1
+  name: ironstone
+
+dashboards:
+  annotations:
+    grafana_folder: Cilium
+  enabled: true
 
 endpointRoutes:
   enabled: true
@@ -19,11 +26,11 @@ hubble:
     enabled:
       - dns:query;ignoreAAAA
       - drop
-      - tcp
       - flow
-      - port-distribution
-      - icmp
       - http
+      - icmp
+      - port-distribution
+      - tcp
   relay:
     enabled: false
     rollOutPods: true
@@ -35,36 +42,16 @@ hubble:
       enabled: false
     rollOutPods: true
 
-prometheus:
-  enabled: true
-  serviceMonitor:
-    enabled: true
-    trustCRDsExist: true
-
-operator:
-  rollOutPods: true
-  prometheus:
-    enabled: true
-    serviceMonitor:
-      enabled: true
-  dashboards:
-    enabled: true
-    annotations:
-      grafana_folder: Cilium
-
-dashboards:
-  enabled: true
-  annotations:
-    grafana_folder: Cilium
-
 ipam:
   mode: kubernetes
 
 ipv4NativeRoutingCIDR: "${CLUSTER_CIDR}"
 k8sServiceHost: "${KUBE_VIP_ADDR}"
 k8sServicePort: 6443
+
 kubeProxyReplacement: true
 kubeProxyReplacementHealthzBindAddr: 0.0.0.0:10256
+
 l2announcements:
   enabled: true
 
@@ -73,7 +60,26 @@ loadBalancer:
   mode: snat
 
 localRedirectPolicy: true
+
+operator:
+  dashboards:
+    annotations:
+      grafana_folder: Cilium
+    enabled: true
+  prometheus:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+  rollOutPods: true
+
+prometheus:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    trustCRDsExist: true
+
 rollOutCiliumPods: true
+
 routingMode: native
 
 securityContext:

--- a/unifi/bgp.cfg
+++ b/unifi/bgp.cfg
@@ -1,0 +1,15 @@
+router bgp 64513
+  bgp router-id 192.168.1.1
+  no bgp ebgp-requires-policy
+
+  neighbor home-kubernetes peer-group
+  neighbor home-kubernetes remote-as 64514
+  neighbor home-kubernetes activate
+  neighbor home-kubernetes capability extended-nexthop
+  neighbor home-kubernetes soft-reconfiguration inbound
+
+  neighbor 192.168.1.200 peer-group home-kubernetes
+
+  address-family ipv4 unicast
+    neighbor home-kubernetes next-hop-self
+  exit-address-family


### PR DESCRIPTION
fix: Add BGP routing policy & reorganise

- Added a new BGP configuration file.
- Reorganized existing settings for clarity.
- Enabled dashboards and Prometheus monitoring options.
- Adjusted hubble settings for better traffic management.
fix: Add BGP routing policy & reorganize Cilium values

- Added a new BGP configuration file.
- Reorganized existing settings for clarity.
- Enabled dashboards and Prometheus monitoring options.
- Adjusted hubble settings for better traffic management.
