### PR TITLE
Always run flux checks

### DIFF
--- a/.github/workflows/flux.yaml
+++ b/.github/workflows/flux.yaml
@@ -5,7 +5,6 @@ name: "Flux & Kubeconform"
 on:
   pull_request:
     branches: ["main"]
-    paths: ["kubernetes/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}


### PR DESCRIPTION
Allows for Ansible updates to trigger this workflow and thus allowing us to
automerge.

Signed-off-by: Dan Webb <dan.webb@damacus.io>
