### PR TITLE
Switch to SMB share (RWX)

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -44,9 +44,9 @@ spec:
 
     persistence:
       enabled: true
-      storageClassName: longhorn
+      storageClassName: smb
       accessModes:
-        - ReadWriteOnce
+        - ReadWriteMany
       size: 50Gi
 
     resources:


### PR DESCRIPTION
This helps avoid multi-attach errors with
RollingDeployments

Signed-off-by: Dan Webb <dan.webb@damacus.io>
