### PR TITLE
Switch from SMB to Longhorn so we have a permissions on the filsystem

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/values.yaml
@@ -82,6 +82,13 @@ operator:
     serviceMonitor:
       enabled: true
   rollOutPods: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 512Mi
 
 prometheus:
   enabled: true

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
   upgrade:
     cleanupOnFail: true
     remediation:
-      strategy: rollback
+      strategy: uninstall
       retries: 3
   values:
     admin:
@@ -44,7 +44,7 @@ spec:
 
     persistence:
       enabled: true
-      storageClassName: smb
+      storageClassName: longhorn
       accessModes:
         - ReadWriteMany
       size: 50Gi


### PR DESCRIPTION
The DB actually cares about the filesystem permissions, so we'll use
Longhorn. SMB is currently mounted with loose permissions

Signed-off-by: Dan Webb <dan.webb@damacus.io>
