### PR TITLE
[home-assistant] Avoid Frigate and Paperless

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
@@ -135,3 +135,24 @@ spec:
             app:
               - path: /tmp
                 subPath: hass-tmp
+
+    affinity:
+      # Prefer to avoid paperless and frigate (soft anti-affinity)
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values: ["paperless"]
+              topologyKey: kubernetes.io/hostname
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values: ["frigate"]
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Should improve stability as these three apps are memory hogs

Signed-off-by: Dan Webb <dan.webb@damacus.io>
