### PR TITLE
Revert moving to cnpg plugin

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
@@ -34,46 +34,21 @@ spec:
       memory: 2Gi
       cpu: 3000m
 
-  plugins:
-    - name: barman-cloud.cloudnative-pg.io
-      isWALArchiver: true
-      parameters:
-        barmanObjectName: *name
----
-apiVersion: barmancloud.cnpg.io/v1
-kind: ObjectStore
-metadata:
-  name: &name home-assistant-db
-spec:
-  retentionPolicy: "30d"
-  configuration:
-    destinationPath: s3://cloudnative-pg/
-    endpointURL: https://eeded8796e30bfe7b412cd59df29bb34.r2.cloudflarestorage.com
-    serverName: *name
-    s3Credentials:
-      accessKeyId:
-        name: r2-cloudnative-pg
-        key: aws-access-key-id
-      secretAccessKey:
-        name: r2-cloudnative-pg
-        key: aws-secret-access-key
-    wal:
-      compression: bzip2
-      maxParallel: 8
-    data:
-      compression: bzip2
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
-apiVersion: postgresql.cnpg.io/v1
-kind: ScheduledBackup
-metadata:
-  name: &name home-assistant-db
-spec:
-  schedule: "0 2 * * *"
-  immediate: true
-  backupOwnerReference: self
-  cluster:
-    name: home-assistant
-  method: plugin
-  pluginConfiguration:
-    name: barman-cloud.cloudnative-pg.io
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      data:
+        compression: bzip2
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      destinationPath: s3://cloudnative-pg/
+      endpointURL: https://eeded8796e30bfe7b412cd59df29bb34.r2.cloudflarestorage.com
+      serverName: *name
+      s3Credentials:
+        accessKeyId:
+          name: r2-cloudnative-pg
+          key: aws-access-key-id
+        secretAccessKey:
+          name: r2-cloudnative-pg
+          key: aws-secret-access-key


### PR DESCRIPTION
There's still a lot of work to do on that plugin. The plugin doesn't yet
have a Helm chart to install all the resources.

We're not doing this:
kubectl apply -f \
        https://github.com/cloudnative-pg/plugin-barman-cloud/releases/download/v0.5.0/manifest.yaml

Seems half baked currently
https://cloudnative-pg.io/plugin-barman-cloud/docs/installation/

Signed-off-by: Dan Webb <dan.webb@damacus.io>
