### PR TITLE
fix(external-dns): suppress IDNA warnings for underscore domains

### DIFF
--- a/kubernetes/apps/network/external-dns/cloudflare/HelmRelease.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/HelmRelease.yaml
@@ -48,6 +48,10 @@ spec:
     txtPrefix: k8s.
     txtOwnerId: ironstone
     domainFilters: ["damacus.io"]
+    excludeDomains:
+      - "_acme-challenge.*"
+      - "_dmarc.*"
+      - "_keybase.*"
     serviceMonitor:
       enabled: true
     podAnnotations:


### PR DESCRIPTION
## Summary

This PR fixes IDNA validation warnings in external-dns logs by adding `excludeDomains` configuration to filter out underscore-prefixed domains.

## Changes

- Added `excludeDomains` configuration to external-dns HelmRelease
- Excludes `_acme-challenge.*`, `_dmarc.*`, and `_keybase.*` domains

## Problem

External-dns was generating warnings like:
```
Got error while parsing domain _acme-challenge.damacus.io: idna: disallowed rune U+005F
Got error while parsing domain _dmarc.damacus.io: idna: disallowed rune U+005F
Got error while parsing domain _keybase.damacus.io: idna: disallowed rune U+005F
```

These warnings occur because IDNA standards don't allow underscores in domain names, but these are legitimate DNS records:
- `_acme-challenge.*` - Let's Encrypt certificate validation
- `_dmarc.*` - Email authentication policies  
- `_keybase.*` - Keybase verification records

## Solution

Configure external-dns to exclude these domains from processing, eliminating the warnings while maintaining full functionality for all other DNS operations.

## Testing

- [x] Applied configuration via Flux reconciliation
- [x] Verified external-dns continues to work for legitimate records
- [ ] Monitor logs to confirm warnings are eliminated