### PR TITLE
fix(frigate): set correct hostPathType for all Rockchip devices

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -101,13 +101,13 @@ spec:
       dri:
         type: hostPath
         hostPath: /dev/dri
-        hostPathType: Directory
+        hostPathType: CharDevice
         globalMounts:
           - path: /dev/dri
       dma-heap:
         type: hostPath
         hostPath: /dev/dma_heap
-        hostPathType: Directory
+        hostPathType: CharDevice
         globalMounts:
           - path: /dev/dma_heap
       rga:


### PR DESCRIPTION
Corrects the hostPathType for /dev/dri and /dev/dma_heap to CharDevice. This was missed in the previous commit and was causing the HelmRelease to fail, resulting in no resources being created by Flux.