### PR TITLE
fix(frigate): correct syntax for sys volume mount

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -101,16 +101,24 @@ spec:
       dri:
         type: hostPath
         hostPath: /dev/dri
-        hostPathType: CharDevice
+        hostPathType: Directory
         globalMounts:
           - path: /dev/dri
 
       rga:
         type: hostPath
         hostPath: /dev/rga
-        hostPathType: CharDevice
+        hostPathType: Directory
         globalMounts:
           - path: /dev/rga
+
+      sys:
+        type: hostPath
+        hostPath: /sys/kernel/debug
+        hostPathType: Directory
+        globalMounts:
+          - path: /sys/kernel/debug
+            readOnly: true
 
     affinity:
       nodeAffinity:


### PR DESCRIPTION
Removes an invalid 'mountPath' property and correctly specifies
'readOnly: true' within the globalMounts section for the /sys/kernel/debug
volume mount. This resolves the Helm chart schema validation error.