### PR TITLE
fix(frigate): set correct hostPathType for all Rockchip devices

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -104,13 +104,24 @@ spec:
         hostPathType: Directory
         globalMounts:
           - path: /dev/dri
-
+      dma-heap:
+        type: hostPath
+        hostPath: /dev/dma_heap
+        hostPathType: Directory
+        globalMounts:
+          - path: /dev/dma_heap
       rga:
         type: hostPath
         hostPath: /dev/rga
-        hostPathType: File
+        hostPathType: CharDevice
         globalMounts:
           - path: /dev/rga
+      mpp-service:
+        type: hostPath
+        hostPath: /dev/mpp_service
+        hostPathType: CharDevice
+        globalMounts:
+          - path: /dev/mpp_service
 
       sys:
         type: hostPath


### PR DESCRIPTION
Ensures all four required Rockchip devices for NPU and VPU
functionality are mounted with the correct hostPathType as determined
by inspecting the host filesystem.

- /dev/dri: Directory
- /dev/dma_heap: Directory
- /dev/rga: CharDevice
- /dev/mpp_service: CharDevice

This definitive fix resolves the 'hostPath type check failed' errors
that were preventing the pod from starting.