### PR TITLE
mount all of sys so that we can get all the sub mounts like /sys/fs/cgroup/cpu.max

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -125,10 +125,10 @@ spec:
 
       sys:
         type: hostPath
-        hostPath: /sys/kernel/debug
+        hostPath: /sys
         hostPathType: Directory
         globalMounts:
-          - path: /sys/kernel/debug
+          - path: /sys
             readOnly: true
 
     affinity:


### PR DESCRIPTION
Signed-off-by: Dan Webb <dan.webb@damacus.io>
