### PR TITLE
Fix n8n deprecations

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -61,9 +61,9 @@ spec:
               EXECUTIONS_DATA_PRUNE: "true"
               EXECUTIONS_DATA_PRUNE_MAX_COUNT: 50000
               EXECUTIONS_MODE: "queue"
-              EXECUTIONS_PROCESS: "main"
               GENERIC_TIMEZONE: "Europe/London"
               N8N_BLOCK_ENV_ACCESS_IN_NODE: "false"
+              N8N_GIT_NODE_DISABLE_BARE_REPOS: "true"
               N8N_COMMUNITY_PACKAGES_ENABLED: "false"
               N8N_DEFAULT_LOCALE: "en_GB"
               N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: "false"
@@ -78,9 +78,10 @@ spec:
               N8N_PORT: &port 5678
               N8N_PROTOCOL: "https"
               N8N_TEMPLATES_ENABLED: "false"
-              N8N_RUNNERS_ENABLED: "false"
+              N8N_RUNNERS_ENABLED: "true"
               WEBHOOK_URL: "https://n8n.ironstone.casa"
               N8N_PROXY_HOPS: "1"
+              OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS: "true"
               NODE_ENV: "production"
               QUEUE_BULL_REDIS_HOST: "redis-master.database.svc.cluster.local"
               QUEUE_BULL_REDIS_PORT: 6379


### PR DESCRIPTION
There are deprecations related to your environment variables. Please take the recommended actions to update your configuration:
 - N8N_RUNNERS_ENABLED -> Running n8n without task runners is deprecated. Task runners will be turned on by default in a future version. Please set `N8N_RUNNERS_ENABLED=true` to enable task runners now and avoid potential issues in the future. Learn more: https://docs.n8n.io/hosting/configuration/task-runners/
 - OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS -> Running manual executions in the main instance in scaling mode is deprecated. Manual executions will be routed to workers in a future version. Please set `OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` to offload manual executions to workers and avoid potential issues in the future. Consider increasing memory available to workers and reducing memory available to main.
 - EXECUTIONS_PROCESS -> Remove this environment variable; it is no longer needed.
 - N8N_GIT_NODE_DISABLE_BARE_REPOS -> Support for bare repositories in the Git Node will be removed in a future version due to security concerns. If you are not using bare repositories in the Git Node, please set N8N_GIT_NODE_DISABLE_BARE_REPOS=true. Learn more: https://docs.n8n.io/hosting/configuration/environment-variables/security/

Signed-off-by: Dan Webb <dan.webb@damacus.io>
