### PR TITLE
fix(victoria-metrics): add global inlineRelabelConfig for metric drops

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -143,8 +143,7 @@ spec:
                 serverName: kubernetes
               metricRelabelConfigs:
                 - action: drop
-                  sourceLabels: [__name__]
-                  regex: "apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket|apiserver_request_body_size_bytes_bucket|apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|apiserver_watch_cache_read_wait_seconds_bucket|etcd_request_duration_seconds_bucket"
+                  if: '{__name__=~"apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket|apiserver_request_body_size_bytes_bucket|apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|apiserver_watch_cache_read_wait_seconds_bucket|etcd_request_duration_seconds_bucket"}'
           jobLabel: component
           namespaceSelector:
             matchNames:

--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -60,6 +60,13 @@ spec:
         podMonitorSelector: {}
         selectAllServiceMonitors: true
         selectAllPodMonitors: true
+        # Global metric relabeling to drop high-cardinality apiserver histogram buckets
+        inlineScrapeConfig: |
+          global:
+            scrape_interval: 30s
+        inlineRelabelConfig:
+          - action: drop
+            if: '{__name__=~"apiserver_request_duration_seconds_bucket|apiserver_request_sli_duration_seconds_bucket|apiserver_request_body_size_bytes_bucket|apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket|apiserver_watch_cache_read_wait_seconds_bucket|etcd_request_duration_seconds_bucket"}'
         # Disk buffering configuration
         extraArgs:
           remoteWrite.tmpDataPath: /var/lib/vmagent-data


### PR DESCRIPTION
Add global relabeling at vmagent level to drop high-cardinality apiserver histogram buckets since per-endpoint metricRelabelConfigs weren't working.