### PR TITLE
fix(envoy): add idle timeout settings for WebSocket connections

### DIFF
--- a/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
@@ -68,6 +68,7 @@ spec:
   tcpKeepalive: {}
   timeout:
     http:
+      connectionIdleTimeout: 0s
       requestTimeout: 0s
   httpUpgrade:
     - type: websocket
@@ -95,6 +96,7 @@ spec:
   tcpKeepalive: {}
   timeout:
     http:
+      idleTimeout: 0s
       requestReceivedTimeout: 0s
   tls:
     minVersion: "1.2"


### PR DESCRIPTION
## Problem
WebSocket connections to Home Assistant get "stuck" after ~2 hours, requiring a pod restart to clear them.

## Root Cause
Envoy Gateway has default idle timeouts:
- `connectionIdleTimeout`: **1 hour** (backend)
- `idleTimeout`: **1 hour** (client)

These timeouts close idle connections, but the frontend doesn't properly reconnect, leaving the UI stuck.

## Solution
Disable idle timeouts for long-lived WebSocket connections:

```yaml
# BackendTrafficPolicy
timeout:
  http:
    connectionIdleTimeout: 0s  # NEW
    requestTimeout: 0s

# ClientTrafficPolicy  
timeout:
  http:
    idleTimeout: 0s  # NEW
    requestReceivedTimeout: 0s
```

## Testing
This fix needs time to validate - the issue manifests after ~2 hours of operation. Monitor Home Assistant WebSocket stability over the next few hours/days.

## References
- [Envoy Gateway HTTPTimeout API](https://gateway.envoyproxy.io/latest/api/extension_types/#httptimeout)
- [HTTPClientTimeout API](https://gateway.envoyproxy.io/latest/api/extension_types/#httpclienttimeout)