### PR TITLE
fix(vector): remove bluetooth recovery filter causing VRL syntax errors

### DIFF
--- a/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
@@ -73,16 +73,6 @@ spec:
           inputs: [remap_kubernetes_logs]
           condition: .label.app == "home-assistant" && contains(string!(.message), "nest integration could not authenticate")
 
-        filter_home_assistant_bluetooth_recovery_logs:
-          type: filter
-          inputs: [remap_kubernetes_logs]
-          condition: |
-            .label.app == "home-assistant" && (
-              contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not determine the power state of the Bluetooth adapter hci1") ||
-              contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not cycle the Bluetooth adapter hci1") ||
-              contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not reset the power state of the Bluetooth adapter hci1")
-            )
-
         nest_auth_metric:
           type: log_to_metric
           inputs: [filter_nest_logs]
@@ -92,32 +82,11 @@ spec:
               name: home_assistant_nest_auth_failure_total
               namespace: home_ops
 
-        home_assistant_bluetooth_recovery_metric:
-          type: log_to_metric
-          inputs: [filter_home_assistant_bluetooth_recovery_logs]
-          metrics:
-            - type: counter
-              field: message
-              name: home_assistant_bluetooth_recovery_warning_total
-              namespace: home_ops
-
-        filter_loki_logs:
-          type: filter
-          inputs: [remap_kubernetes_logs]
-          condition: |
-            !(
-              .label.app == "home-assistant" && (
-                contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not determine the power state of the Bluetooth adapter hci1") ||
-                contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not cycle the Bluetooth adapter hci1") ||
-                contains(string!(.message), "[bluetooth_auto_recovery.recover] Could not reset the power state of the Bluetooth adapter hci1")
-              )
-            )
-
       # Sinks
       sinks:
         loki:
           type: loki
-          inputs: [filter_loki_logs]
+          inputs: [remap_kubernetes_logs]
           endpoint: http://loki-gateway.monitoring.svc.cluster.local
           encoding:
             codec: json
@@ -134,7 +103,7 @@ spec:
 
         prometheus_sink:
           type: prometheus_exporter
-          inputs: [nest_auth_metric, home_assistant_bluetooth_recovery_metric, internal_metrics]
+          inputs: [nest_auth_metric, internal_metrics]
           address: 0.0.0.0:9090
 
     # Persistence for buffering

--- a/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
@@ -18,6 +18,7 @@ spec:
     remediation:
       retries: 3
   upgrade:
+    timeout: 15m
     cleanupOnFail: true
     remediation:
       retries: 3


### PR DESCRIPTION
## Summary
- Removes the `filter_home_assistant_bluetooth_recovery_logs`, `home_assistant_bluetooth_recovery_metric`, and `filter_loki_logs` transforms added in #3190
- Reverts the Loki sink input back to `remap_kubernetes_logs`

## Why
VRL filter conditions cannot span multiple lines, and Helm's YAML serializer folds long strings (>~80 chars), inserting newlines that break VRL parsing. The three `contains()` calls joined with `||` produce conditions too long to fit on one line, and there's no clean workaround within the HelmRelease `customConfig` values.

Removing these avoids the VRL crash that has kept Vector in a rollback loop since #3190. Bluetooth recovery logs will flow through to Loki again — noise reduction can be revisited using a ConfigMap Kustomize patch that bypasses Helm serialization.

## Test plan
- [ ] Verify `kubectl get helmrelease vector -n monitoring` shows READY=True after merge
- [ ] Verify Vector pods start cleanly without VRL syntax errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
