### PR TITLE
fix: auto-merge selected renovate assets

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,8 +15,11 @@
     {
       description: "Auto-merge non-major updates for selected home-ops assets",
       matchPackageNames: [
+        "ghcr.io/coder/code-server",
         "ghcr.io/damacus/med-tracker",
+        "ghcr.io/mealie-recipes/mealie",
         "ghcr.io/paperless-ngx/paperless-ngx",
+        "registry.k8s.io/kubectl",
         "ghcr.io/zitadel/zitadel",
         "victoria-metrics-k8s-stack",
         "zitadel",


### PR DESCRIPTION
## Summary
- extend the existing Renovate auto-merge rule for selected home-ops assets
- add `ghcr.io/coder/code-server`, `registry.k8s.io/kubectl`, and `ghcr.io/mealie-recipes/mealie`
- keep `ghcr.io/damacus/med-tracker` on the same rule, since it was already covered

## Validation
- parsed `.github/renovate.json5` locally with Node to confirm the JSON5 config remains valid
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
