### PR TITLE
fix: restore rustfs startup config

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -9,4 +9,4 @@ resources:
   - ./csi-driver-smb/ks.yaml
   - ./longhorn/ks.yaml
   - ./minio/ks.yaml
-  # - ./rustfs/ks.yaml
+  - ./rustfs/ks.yaml

--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
         replicas: 1
         annotations:
           reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 988
+            fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
             image:
@@ -37,24 +41,40 @@ spec:
               TZ: "${TZ}"
               RUSTFS_VOLUMES: /data
               RUSTFS_ADDRESS: :9000
+              RUSTFS_CONSOLE_ENABLE: "true"
               RUSTFS_CONSOLE_ADDRESS: :9001
               RUSTFS_OBS_METRIC_ENDPOINT: http://vmsingle-vm.monitoring.svc.cluster.local:8428/opentelemetry/api/v1/push
             envFrom:
               - secretRef:
                   name: rustfs-credentials
+            args: ["/data"]
             probes:
-              liveness: &probes
+              liveness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /minio/health/live
+                    path: /rustfs/health/live
                     port: 9000
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 10
                   failureThreshold: 6
-              readiness: *probes
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /rustfs/health/ready
+                    port: 9000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+            securityContext:
+              runAsUser: 977
+              runAsGroup: 988
+              runAsNonRoot: true
             resources:
               requests:
                 cpu: 100m

--- a/kubernetes/apps/storage/rustfs/app/pvc.yaml
+++ b/kubernetes/apps/storage/rustfs/app/pvc.yaml
@@ -9,4 +9,4 @@ spec:
   resources:
     requests:
       storage: 500Gi
-  storageClassName: nfs-csi-ssd
+  storageClassName: nfs-csi-unas


### PR DESCRIPTION
## Summary
- restore the RustFS startup manifest to the repos previously hardened NFS-safe configuration
- add an explicit RustFS data path argument and switch liveness/readiness probes to RustFS health endpoints
- re-enable the RustFS Flux kustomization and return the PVC to the known-good `nfs-csi-unas` storage class

## Verification
- `task kubernetes:kubeconform`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3320" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
