### PR TITLE
feat: add med-tracker dmd import

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/dmd-import-externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/dmd-import-externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: med-tracker-dmd-import-env
+  namespace: home
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: med-tracker-dmd-import-env
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .username }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .password }}"
+        AWS_DEFAULT_REGION: us-east-1
+        AWS_EC2_METADATA_DISABLED: "true"
+        AWS_ENDPOINT_URL_S3: http://minio.storage.svc.cluster.local:9000
+        DMD_RELEASE_URI: s3://med-tracker/nhs-dmd/releases/2026-04-12/current/
+  dataFrom:
+    - extract:
+        key: minio-cnpg

--- a/kubernetes/apps/home/med-tracker/app/dmd-import-job.yaml
+++ b/kubernetes/apps/home/med-tracker/app/dmd-import-job.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  # Rename this Job for each real release import. Job specs are immutable, and
+  # a new name makes each import explicit in Git history.
+  name: med-tracker-import-dmd-release-2026-04-12
+  namespace: home
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+        - name: fetch-dmd-release
+          image: amazon/aws-cli:2.22.35
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              mkdir -p /work/nhs-dmd/current
+
+              if [ "${DMD_RELEASE_URI:-SET_ME}" = "SET_ME" ]; then
+                echo "DMD_RELEASE_URI is still SET_ME; skipping dm+d download."
+                echo "Set a real release path in med-tracker-dmd-import-env and rename this Job to run an import."
+                exit 0
+              fi
+
+              aws s3 sync "${DMD_RELEASE_URI}" /work/nhs-dmd/current --no-progress
+
+              if ! find /work/nhs-dmd/current -maxdepth 1 -name 'f_ampp2_3*.xml' | grep -q .; then
+                echo "Missing f_ampp2_3*.xml in ${DMD_RELEASE_URI}."
+                exit 1
+              fi
+
+              if ! find /work/nhs-dmd/current -maxdepth 1 -name 'f_gtin2_0*.xml' | grep -q .; then
+                echo "Missing extracted f_gtin2_0*.xml in ${DMD_RELEASE_URI}."
+                echo "Upload extracted XML files rather than the GTIN ZIP for Kubernetes imports."
+                exit 1
+              fi
+          envFrom:
+            - secretRef:
+                name: med-tracker-dmd-import-env
+          volumeMounts:
+            - name: dmd-release
+              mountPath: /work/nhs-dmd
+      containers:
+        - name: import-dmd-release
+          image: ghcr.io/damacus/med-tracker:0.3.36
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              if [ "${DMD_RELEASE_URI:-SET_ME}" = "SET_ME" ]; then
+                echo "DMD_RELEASE_URI is still SET_ME; skipping dm+d import."
+                echo "Set a versioned s3:// release path and rename this Job to run a real import."
+                exit 0
+              fi
+
+              bundle exec rails runner db/seeds/import_nhs_dmd_release.rb /work/nhs-dmd/current
+          env:
+            - name: RAILS_ENV
+              value: production
+          envFrom:
+            - secretRef:
+                name: med-tracker-secret
+            - secretRef:
+                name: med-tracker-dmd-import-env
+          volumeMounts:
+            - name: dmd-release
+              mountPath: /work/nhs-dmd
+      volumes:
+        - name: dmd-release
+          emptyDir: {}

--- a/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
@@ -23,6 +23,8 @@ spec:
   dataFrom:
     - extract:
         key: med-tracker
+    - extract:
+        key: med-tracker-oidc
   data:
     - secretKey: db_password
       remoteRef:

--- a/kubernetes/apps/home/med-tracker/app/kustomization.yaml
+++ b/kubernetes/apps/home/med-tracker/app/kustomization.yaml
@@ -6,4 +6,6 @@ namespace: home
 resources:
   - helmrelease.yaml
   - externalsecret.yaml
+  - dmd-import-externalsecret.yaml
+  - dmd-import-job.yaml
   - storage-pvc.yaml


### PR DESCRIPTION
## Summary
- merge the med-tracker-oidc secret into the MedTracker runtime ExternalSecret
- add a one-off dm+d import ExternalSecret and Kubernetes Job for the 2026-04-12 release
- point the import job at s3://med-tracker/nhs-dmd/releases/2026-04-12/current/

## Verification
- task kubernetes:kubeconform
- verified the staged MinIO release directory contains both f_ampp2_3090426.xml and f_gtin2_0090426.xml
- verified the import credentials can read the release prefix

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
