### PR TITLE
fix: rerun med-tracker dmd import

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/dmd-import-job.yaml
+++ b/kubernetes/apps/home/med-tracker/app/dmd-import-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   # Rename this Job for each real release import. Job specs are immutable, and
   # a new name makes each import explicit in Git history.
-  name: med-tracker-import-dmd-release-2026-04-12
+  name: med-tracker-import-dmd-release-2026-04-12-rerun
   namespace: home
 spec:
   backoffLimit: 0


### PR DESCRIPTION
## Summary
- rename the MedTracker dm+d import Job so Flux creates a fresh one-off Job object
- keep the import pointed at the staged 2026-04-12 dm+d release on MinIO
- unblock the rerun now that MedTracker v0.3.37 is live

## Context
The previous Job failed because it ran on image 0.3.36 and the importer script was not present in that image.

## Verification
- task kubernetes:kubeconform
- verified the previous failed Job downloaded both XML files before the importer step
- verified the live MedTracker deployment is on 0.3.37

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
