### PR TITLE
fix: use rustfs health endpoint

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -54,7 +54,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /rustfs/health/live
+                    path: /health
                     port: 9000
                   initialDelaySeconds: 30
                   periodSeconds: 30
@@ -65,7 +65,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /rustfs/health/ready
+                    path: /health
                     port: 9000
                   initialDelaySeconds: 10
                   periodSeconds: 10


### PR DESCRIPTION
## Summary
- switch RustFS liveness and readiness probes from `/rustfs/health/*` to `/health` on port `9000`
- align the probe configuration with the actual behavior of `rustfs/rustfs:1.0.0-alpha.90`
- avoid the kubelet restart loop caused by the current probe paths returning `403 Forbidden`

## Verification
- `task kubernetes:kubeconform`
- verified inside the live pod that `/health` returns `200` while `/rustfs/health/live` and `/rustfs/health/ready` return `403`
- verified the same behavior in a fresh local `docker run` of `rustfs/rustfs:1.0.0-alpha.90`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
