### PR TITLE
feat: add med-tracker logs dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ provisioning/.ruby-lsp/
 
 claude-progress.txt
 message.txt
+
+# Python caches
+__pycache__/
+scripts/__pycache__/

--- a/kubernetes/apps/home/med-tracker/app/grafana-dashboard.yaml
+++ b/kubernetes/apps/home/med-tracker/app/grafana-dashboard.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: med-tracker-logs-dashboard
+  namespace: home
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: Home
+data:
+  med-tracker-logs.json: |
+    {
+      "id": null,
+      "uid": "med-tracker-logs",
+      "title": "Med Tracker Logs",
+      "tags": ["med-tracker", "logs"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "10s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Parsed Application Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "{namespace=\"home\", app=\"med-tracker\"} | json level=\"log.level\", path=\"url.path\", method=\"http.request.method\", status=\"http.response.status_code\" | line_format `{{.message}} {{if .method}}{{.method}} {{end}}{{if .path}}{{.path}}{{end}}{{if .status}}status={{.status}} {{end}}{{if .level}}level={{.level}}{{end}}`",
+              "queryType": "range"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": true,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          }
+        },
+        {
+          "id": 2,
+          "title": "Raw Stream",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 14
+          },
+          "targets": [
+            {
+              "refId": "B",
+              "expr": "{namespace=\"home\", app=\"med-tracker\"}",
+              "queryType": "range"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": true,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/home/med-tracker/app/kustomization.yaml
+++ b/kubernetes/apps/home/med-tracker/app/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - externalsecret.yaml
   - dmd-import-externalsecret.yaml
   - dmd-import-job.yaml
+  - grafana-dashboard.yaml
   - storage-pvc.yaml


### PR DESCRIPTION
## Summary
- add a Grafana dashboard ConfigMap for Med Tracker logs
- include the dashboard in the Med Tracker app kustomization
- ignore generated Python __pycache__ files under scripts

## Validation
- task kubernetes:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
