### PR TITLE
feat: add rustfs ssd migration workflow

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -36,6 +36,38 @@ tasks:
           sh: "test -f {{.KUBECONFORM_SCRIPT}}",
         }
 
+  object-storage-migrate:
+    desc: Copy or sync objects between MinIO and RustFS with local rclone
+    summary: |
+      Reads S3 credentials from the live Kubernetes secrets in the storage
+      namespace and uses local rclone to copy or sync objects between the
+      MinIO and RustFS S3 endpoints.
+
+      Examples:
+        task kubernetes:object-storage-migrate
+        task kubernetes:object-storage-migrate source_path=med-tracker destination_path=med-tracker
+        task kubernetes:object-storage-migrate mode=sync dry_run=true
+    vars:
+      SCRIPT: "{{.ROOT_DIR}}/scripts/object_storage_migrate.sh"
+      SOURCE: '{{.source | default "minio"}}'
+      DESTINATION: '{{.destination | default "rustfs"}}'
+      MODE: '{{.mode | default "copy"}}'
+      SOURCE_PATH: '{{.source_path | default ""}}'
+      DESTINATION_PATH: '{{.destination_path | default ""}}'
+      DRY_RUN: '{{.dry_run | default "false"}}'
+    cmd: >-
+      bash {{.SCRIPT}}
+      --source {{.SOURCE}}
+      --destination {{.DESTINATION}}
+      --mode {{.MODE}}
+      {{if .SOURCE_PATH}}--source-path {{.SOURCE_PATH}}{{end}}
+      {{if .DESTINATION_PATH}}--destination-path {{.DESTINATION_PATH}}{{end}}
+      {{if eq .DRY_RUN "true"}}--dry-run{{end}}
+    preconditions:
+      - { msg: "Missing migration script", sh: "test -f {{.SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
+      - { msg: "Missing rclone", sh: "command -v rclone >/dev/null" }
+
   edge-smoke:
     desc: Run baseline HTTP and WebSocket smoke checks for the Traefik edge
     summary: |

--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -116,6 +116,6 @@ spec:
 
     persistence:
       data:
-        existingClaim: rustfs-data
+        existingClaim: rustfs-data-ssd
         globalMounts:
           - path: /data

--- a/kubernetes/apps/storage/rustfs/app/kustomization.yaml
+++ b/kubernetes/apps/storage/rustfs/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./pvc-ssd.yaml

--- a/kubernetes/apps/storage/rustfs/app/pvc-ssd.yaml
+++ b/kubernetes/apps/storage/rustfs/app/pvc-ssd.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustfs-data-ssd
+  namespace: storage
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: 500Gi
+  storageClassName: nfs-csi-ssd

--- a/scripts/object_storage_migrate.sh
+++ b/scripts/object_storage_migrate.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SOURCE_REMOTE="minio"
+DEST_REMOTE="rustfs"
+SOURCE_PATH=""
+DEST_PATH=""
+MODE="copy"
+DRY_RUN="false"
+
+usage() {
+  cat <<'EOF'
+Usage: object_storage_migrate.sh [options]
+
+Copy or sync objects between the MinIO and RustFS S3 endpoints using rclone.
+Credentials are read from the live Kubernetes secrets in the storage namespace.
+
+Options:
+  --source <minio|rustfs>       Source remote (default: minio)
+  --destination <minio|rustfs>  Destination remote (default: rustfs)
+  --source-path <path>          Optional bucket/prefix on the source remote
+  --destination-path <path>     Optional bucket/prefix on the destination remote
+  --mode <copy|sync>            rclone mode (default: copy)
+  --dry-run                     Show what would change without copying objects
+  --help                        Show this message
+EOF
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+normalize_path() {
+  local raw="${1:-}"
+  raw="${raw#/}"
+  printf '%s' "$raw"
+}
+
+secret_value() {
+  local namespace="$1"
+  local secret_name="$2"
+  local secret_key="$3"
+
+  kubectl get secret -n "$namespace" "$secret_name" -o "jsonpath={.data.${secret_key}}" | base64 --decode
+}
+
+remote_endpoint() {
+  case "$1" in
+    minio) printf '%s' 'https://s3.ironstone.casa' ;;
+    rustfs) printf '%s' 'https://rustfs-s3.ironstone.casa' ;;
+    *)
+      echo "Unsupported remote: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+remote_access_key() {
+  case "$1" in
+    minio) secret_value storage minio-root-user MINIO_ROOT_USER ;;
+    rustfs) secret_value storage rustfs-credentials RUSTFS_ACCESS_KEY ;;
+    *)
+      echo "Unsupported remote: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+remote_secret_key() {
+  case "$1" in
+    minio) secret_value storage minio-root-user MINIO_ROOT_PASSWORD ;;
+    rustfs) secret_value storage rustfs-credentials RUSTFS_SECRET_KEY ;;
+    *)
+      echo "Unsupported remote: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --source)
+      SOURCE_REMOTE="$2"
+      shift 2
+      ;;
+    --destination)
+      DEST_REMOTE="$2"
+      shift 2
+      ;;
+    --source-path)
+      SOURCE_PATH="$2"
+      shift 2
+      ;;
+    --destination-path)
+      DEST_PATH="$2"
+      shift 2
+      ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$MODE" != "copy" && "$MODE" != "sync" ]]; then
+  echo "Unsupported mode: $MODE" >&2
+  exit 1
+fi
+
+if [[ "$SOURCE_REMOTE" == "$DEST_REMOTE" ]]; then
+  echo "Source and destination remotes must differ" >&2
+  exit 1
+fi
+
+require_command kubectl
+require_command rclone
+require_command base64
+
+SOURCE_PATH="$(normalize_path "$SOURCE_PATH")"
+DEST_PATH="$(normalize_path "$DEST_PATH")"
+
+RCLONE_CONFIG_FILE="$(mktemp)"
+trap 'rm -f "$RCLONE_CONFIG_FILE"' EXIT
+
+cat >"$RCLONE_CONFIG_FILE" <<EOF
+[$SOURCE_REMOTE]
+type = s3
+provider = Minio
+env_auth = false
+endpoint = $(remote_endpoint "$SOURCE_REMOTE")
+access_key_id = $(remote_access_key "$SOURCE_REMOTE")
+secret_access_key = $(remote_secret_key "$SOURCE_REMOTE")
+
+[$DEST_REMOTE]
+type = s3
+provider = Minio
+env_auth = false
+endpoint = $(remote_endpoint "$DEST_REMOTE")
+access_key_id = $(remote_access_key "$DEST_REMOTE")
+secret_access_key = $(remote_secret_key "$DEST_REMOTE")
+EOF
+
+SOURCE_SPEC="${SOURCE_REMOTE}:"
+DEST_SPEC="${DEST_REMOTE}:"
+
+if [[ -n "$SOURCE_PATH" ]]; then
+  SOURCE_SPEC="${SOURCE_REMOTE}:${SOURCE_PATH}"
+fi
+
+if [[ -n "$DEST_PATH" ]]; then
+  DEST_SPEC="${DEST_REMOTE}:${DEST_PATH}"
+fi
+
+RCLONE_ARGS=(
+  --config "$RCLONE_CONFIG_FILE"
+  "$MODE"
+  "$SOURCE_SPEC"
+  "$DEST_SPEC"
+  --fast-list
+  --checkers 16
+  --transfers 8
+  --s3-no-check-bucket
+  --progress
+)
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  RCLONE_ARGS+=(--dry-run)
+fi
+
+echo "Source:      $SOURCE_SPEC"
+echo "Destination: $DEST_SPEC"
+echo "Mode:        $MODE"
+echo "Dry run:     $DRY_RUN"
+
+rclone "${RCLONE_ARGS[@]}"


### PR DESCRIPTION
## Summary
- point RustFS at a new SSD-backed NFS claim instead of the existing UNAS claim
- keep the old claim defined so data can be migrated before cleanup
- add a local rclone-based helper and Taskfile entry to copy or sync objects from MinIO to RustFS
- keep RustFS health probes on the verified `/health` endpoint

## Validation
- bash -n scripts/object_storage_migrate.sh
- task kubernetes:kubeconform

## Notes
- this changes RustFS to mount a new PVC named `rustfs-data-ssd`
- the old `rustfs-data` claim is intentionally left in place so the data migration can happen before it is removed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
