### PR TITLE
fix: quiet rustfs metric logging

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -43,7 +43,11 @@ spec:
               RUSTFS_ADDRESS: :9000
               RUSTFS_CONSOLE_ENABLE: "true"
               RUSTFS_CONSOLE_ADDRESS: :9001
+              RUSTFS_OBS_ENDPOINT: http://vmsingle-vm.monitoring.svc.cluster.local:8428
               RUSTFS_OBS_METRIC_ENDPOINT: http://vmsingle-vm.monitoring.svc.cluster.local:8428/opentelemetry/api/v1/push
+              RUSTFS_OBS_USE_STDOUT: "false"
+              RUSTFS_OBS_TRACES_EXPORT_ENABLED: "false"
+              RUSTFS_OBS_LOGS_EXPORT_ENABLED: "false"
             envFrom:
               - secretRef:
                   name: rustfs-credentials


### PR DESCRIPTION
## Summary
- keep RustFS metrics flowing to VictoriaMetrics via the OTLP metric endpoint
- set a root OTLP endpoint so RustFS honors RUSTFS_OBS_USE_STDOUT=false
- disable unused RustFS trace and log OTLP exporters

## Verification
- yq parsed the edited RustFS env block
- git diff --check
- task kubernetes:kubeconform
- pre-commit hooks during commit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
