### PR TITLE
fix: use Zitadel secret for MedTracker OIDC

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
@@ -33,7 +33,7 @@ spec:
     - extract:
         key: med-tracker
     - extract:
-        key: med-tracker-oidc
+        key: zitadel-med-tracker-oidc
   data:
     - secretKey: db_password
       remoteRef:


### PR DESCRIPTION
## Summary
- point MedTracker ExternalSecret at the Zitadel-specific OIDC 1Password item
- leave the OIDC_CLIENT_ID/OIDC_CLIENT_SECRET template keys unchanged
- keep med-tracker-oidc available for NHS DM+D credentials

## Tests
- yamllint kubernetes/apps/home/med-tracker/app/externalsecret.yaml
- task kubernetes:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3371" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
