### PR TITLE
fix: extend home assistant helm timeout

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
@@ -6,6 +6,7 @@ metadata:
   name: home-assistant
 spec:
   interval: 30m
+  timeout: 15m
   chart:
     spec:
       chart: app-template


### PR DESCRIPTION
Extends the Home Assistant HelmRelease timeout to 15 minutes. The SSD-to-HDD migration changes are already merged, but Home Assistant rolled back because the default 5 minute Helm timeout fired while the pod was still pulling/starting.\n\nI also patched the live HelmRelease with the same timeout and manually moved the StatefulSet back to home-assistant-nfs-csi-hdd so the pod can schedule.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
