### PR TITLE
feat(echo-server): trial app-template v5

### DIFF
--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- bump only network/echo-server from app-template 4.6.2 to 5.0.0
- use echo-server as a low-risk stateless canary before rolling v5 across the remaining app-template releases

## Validation
- flux-local full-tree validation: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3394" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->