### PR TITLE
feat(helm): batch app-template v5

### DIFF
--- a/kubernetes/apps/default/unifi-release-announcer/app/HelmRelease.yaml
+++ b/kubernetes/apps/default/unifi-release-announcer/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/piper/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/piper/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/wakeword/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/wakeword/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/whisper/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/whisper/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- bump the next low-risk app-template workloads from 4.6.2 to 5.0.0
- includes unifi-release-announcer, wyoming-piper, wyoming-openwakeword, and wyoming-whisper
- follows the successful echo-server canary rollout in #3394

## Cluster canary result
- echo-server HelmRelease is Ready on app-template 5.0.0
- echo-server Deployment is 1/1 ready with zero restarts
- internal and external health endpoints returned HTTP 200

## Validation
- flux-local full-tree validation: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->