### PR TITLE
feat(helm): continue app-template v5

### DIFF
--- a/kubernetes/apps/home-automation/codeserver/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/codeserver/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home/trillium-next/app/helmrelease.yaml
+++ b/kubernetes/apps/home/trillium-next/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- bump the next app-template workload batch from 4.6.2 to 5.0.0
- includes code, n8n, and trillium-next
- follows successful cluster reconciliation of the prior app-template batch

## Cluster result for previous batch
- unifi-release-announcer Ready on app-template 5.0.0, pod 1/1 running with 0 restarts
- wyoming-piper Ready on app-template 5.0.0, pod 1/1 running with 0 restarts
- wyoming-whisper Ready on app-template 5.0.0, pod 1/1 running with 0 restarts
- wyoming-openwakeword is changed in Git but is not currently included by the home-automation kustomization, so there is no live resource to poll

## Validation
- flux-local full-tree validation: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3397" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->