### PR TITLE
feat(helm): migrate user apps to app-template v5

### DIFF
--- a/kubernetes/apps/home-automation/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/paperless/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       interval: 30m
       sourceRef:
         kind: HelmRepository

--- a/kubernetes/apps/home/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mealie/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- update mealie, med-tracker, and paperless app-template charts to 5.0.0
- keep this batch scoped to live user-facing apps after the previous app-template v5 batch reconciled successfully

## Validation
- flux-local full-tree render: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->