### PR TITLE
feat(helm): migrate automation services to app-template v5

### DIFF
--- a/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       interval: 15m
       sourceRef:
         kind: HelmRepository

--- a/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/mosquitto/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- update matter-server and mosquitto app-template charts to 5.0.0
- keep home-assistant, frigate, storage, tunnel, secrets, and controller workloads for later isolated batches

## Validation
- flux-local full-tree render: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->