### PR TITLE
feat(helm): finish app-template v5 migration

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/unpoller/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/storage/minio/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/minio/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/config/values.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/config/values.yaml
@@ -30,6 +30,7 @@ controllers:
           seccompProfile:
             type: RuntimeDefault
     pod:
+      automountServiceAccountToken: true
       securityContext:
         runAsUser: 65534
         runAsGroup: 65534

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.0
       sourceRef:
         kind: HelmRepository
         name: bjw-s


### PR DESCRIPTION
## Summary
- update the remaining live app-template HelmRepository releases to 5.0.0: onepassword-connect, frigate, home-assistant, cloudflared, minio, rustfs, and system-upgrade-controller
- update the non-live unpoller manifest to 5.0.0 for repository consistency
- preserve system-upgrade-controller API access by explicitly enabling service account token automounting under app-template v5 defaults

## Notes
- database/dragonfly is not included here because PR #3388 already tracks the OCI app-template tag update
- unpoller is not currently included by the monitoring parent kustomization, so it will not roll out until that inclusion gap is handled

## Validation
- flux-local full-tree render: 118 passed
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3401" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->