### PR TITLE
fix: improve frigate ios recordings

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -103,8 +103,8 @@ spec:
         type: configMap
         name: frigate-configmap
         globalMounts:
-          - path: /config/config.yml
-            subPath: config.yml
+          - path: /config/config.yaml
+            subPath: config.yaml
             readOnly: true
       media:
         existingClaim: frigate-media

--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -27,6 +27,12 @@ model:
 ffmpeg:
   hwaccel_args: preset-rkmpp
   apple_compatibility: true
+  output_args:
+    record: >-
+      -f segment -segment_time 10 -segment_format mp4 -reset_timestamps 1
+      -strftime 1 -vf scale=in_range=pc:out_range=tv,format=yuv420p
+      -c:v h264_rkmpp -profile:v main -level:v 41 -g 30 -r 15
+      -c:a aac
 
 record:
   enabled: true


### PR DESCRIPTION
## Summary
- encode Frigate recordings with Rockchip H.264 output that is friendlier to iOS playback
- mount the GitOps Frigate config at /config/config.yaml, matching the file Frigate loads

## Verification
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->