### PR TITLE
fix: improve frigate live streams

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -55,8 +55,12 @@ go2rtc:
       - rtsp://192.168.1.180:8554/main
       - "ffmpeg:birdy#audio=aac"
       - "ffmpeg:birdy#audio=opus"
+    birdy_live:
+      - "ffmpeg:birdy#video=copy#audio=aac"
     birdy_sub:
       - rtsp://192.168.1.180:8554/sub
+    birdy_sub_live:
+      - "ffmpeg:birdy_sub#video=copy#audio=aac"
 
 cameras:
   birdy:
@@ -77,8 +81,8 @@ cameras:
       fps: 5
     live:
       streams:
-        Main: birdy
-        Sub: birdy_sub
+        Main: birdy_live
+        Sub: birdy_sub_live
     objects:
       filters:
         bird: {}


### PR DESCRIPTION
## Summary
- add browser-focused go2rtc live stream aliases for main and sub feeds
- keep Frigate record/detect inputs on the existing raw restreams
- point the Frigate live menu at AAC browser-safe streams to avoid PCMA/MSE fallback

## Verification
- task k8s:kubeconform
- Frigate API config shows Main -> birdy_live and Sub -> birdy_sub_live
- go2rtc exposes birdy_live and birdy_sub_live
- ffprobe birdy_live: H.264 Main 1920x1080 15 fps + AAC LC 8 kHz mono
- ffprobe birdy_sub_live: H.264 Main 640x360 15 fps + AAC LC 8 kHz mono

## Notes
- This does not change the recording or detection inputs.
- The ConfigMap still mounts as /config/config.yaml; this PR does not switch it back to /config/config.yml.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->