### PR TITLE
fix: stabilize frigate live view

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -60,11 +60,11 @@ go2rtc:
       - "ffmpeg:birdy#audio=aac"
       - "ffmpeg:birdy#audio=opus"
     birdy_live:
-      - "ffmpeg:birdy#video=h264"
+      - "ffmpeg:birdy#video=h264#audio=aac/16000"
     birdy_sub:
       - rtsp://192.168.1.180:8554/sub
     birdy_sub_live:
-      - "ffmpeg:birdy_sub#video=h264"
+      - "ffmpeg:birdy_sub#video=h264#audio=aac/16000"
 
 cameras:
   birdy:

--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -50,17 +50,21 @@ objects:
   track: ["bird"]
 
 go2rtc:
+  ffmpeg:
+    h264: >-
+      -vf format=yuv420p -codec:v h264_rkmpp -profile:v main -level:v 41
+      -g:v 15 -r 15 -bf:v 0
   streams:
     birdy:
       - rtsp://192.168.1.180:8554/main
       - "ffmpeg:birdy#audio=aac"
       - "ffmpeg:birdy#audio=opus"
     birdy_live:
-      - "ffmpeg:birdy#video=copy#audio=aac"
+      - "ffmpeg:birdy#video=h264"
     birdy_sub:
       - rtsp://192.168.1.180:8554/sub
     birdy_sub_live:
-      - "ffmpeg:birdy_sub#video=copy#audio=aac"
+      - "ffmpeg:birdy_sub#video=h264"
 
 cameras:
   birdy:


### PR DESCRIPTION
## Summary
- keep the clean H.264 re-encode for main and sub Frigate live streams
- restore live audio by transcoding camera G.711 A-law to AAC-LC 16 kHz mono
- keep the existing raw restreams for recording and detection so the improved recordings remain unchanged

## Why
The camera exposes H.264 video plus G.711 A-law audio on the newer Green Feathers/Tuya-style RTSP URLs at :8554/main and :8554/sub. Browser live playback was unstable when Frigate copied the camera H.264 directly into MSE. Re-encoding only the Live UI video gives the browser a clean H.264 stream, while transcoding audio to AAC preserves live sound without returning to the fragile copy-video path.

## Camera notes
- Product docs identify this as a Green Feathers wired network/PoE bird box camera with built-in microphone, 1080p main stream, 640x480 sub stream, RTSP, and ONVIF support.
- The camera refused RTSP on port 554, so it is not using the older stream0/stream1 URL family.
- Active source streams are rtsp://192.168.1.180:8554/main and /sub, with H.264 video and G.711 A-law audio.

## Verification
- task k8s:kubeconform
- applied to the live Frigate deployment and rolled it out
- Frigate API/go2rtc config shows birdy_live and birdy_sub_live use video=h264#audio=aac/16000
- ffprobe birdy_live: AAC-LC 16 kHz mono + H.264 Main 1920x1080 15 fps
- ffprobe birdy_sub_live: AAC-LC 16 kHz mono + H.264 Main 640x360 15 fps
- macOS live view was much smoother with the clean H.264 path before audio was restored; AAC-restored build is deployed for browser verification
- recordings remain unchanged and still use the existing iOS-safe recording transcode