### PR TITLE
fix: align rustfs with nfs export

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/rustfs/app/helmrelease.yaml
@@ -78,9 +78,9 @@ spec:
                   failureThreshold: 6
             securityContext:
               allowPrivilegeEscalation: false
-              runAsUser: 0
-              runAsGroup: 0
-              runAsNonRoot: false
+              runAsUser: 977
+              runAsGroup: 988
+              runAsNonRoot: true
               capabilities:
                 drop: ["ALL"]
             resources:

--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rustfs-buckets-create
+  name: rustfs-buckets-create-v2
   namespace: storage
 spec:
   backoffLimit: 6
@@ -28,15 +28,23 @@ spec:
               set -eu
               echo "Configuring mc alias and waiting for RustFS at ${RUSTFS_ENDPOINT:?}..."
               i=1
+              ready=false
               while [ "$i" -le 60 ]; do
                 if mc alias set rustfs "${RUSTFS_ENDPOINT:?}" "${RUSTFS_ACCESS_KEY:?}" "${RUSTFS_SECRET_KEY:?}" >/dev/null 2>&1; then
                   if mc ls rustfs >/dev/null 2>&1; then
-                    echo "RustFS is reachable"; break
+                    echo "RustFS is reachable"
+                    ready=true
+                    break
                   fi
                 fi
                 echo "Attempt $i: RustFS not ready, retrying..."; sleep 5
                 i=$((i + 1))
               done
+
+              if [ "$ready" != "true" ]; then
+                echo "RustFS did not become reachable in time"
+                exit 1
+              fi
 
               for b in ${BUCKETS}; do
                 echo "Creating bucket: $b"


### PR DESCRIPTION
## Summary
- keep RustFS on the existing `nfs-csi-unas` PVC and run it as the export anon UID/GID `977:988`
- replace the bucket bootstrap Job with `rustfs-buckets-create-v2` so Flux creates a fresh Job instead of trying to mutate an immutable completed Job
- make the bucket bootstrap fail hard if RustFS never becomes reachable

## Root cause
The NFS export for `/var/nfs/shared/nfs` uses `all_squash,anonuid=977,anongid=988`, but the existing RustFS PVC subdir was `root:root 0755`, so all Kubernetes clients were mapped to `977:988` and denied writes. This caused RustFS `FileAccessDenied` and Loki S3 `403 AccessDenied` errors.

## Live remediation already applied
- chowned/chmodded only the existing RustFS PVC subdir on `unas.ironstone.casa` to `977:988`
- created the required RustFS buckets in-place: `cnpg-backups`, `loki-data`, `loki-chunks`
- forced/reset Loki HelmRelease reconcile; Loki is now `2/2 Running` and `Ready=True`

## Validation
- `git diff --check`
- `task kubernetes:kubeconform`
- live RustFS write test passed on `/data`
- no RustFS permission errors in recent logs
- no recent Loki S3 AccessDenied/PutObject/DeleteObject failures after rollout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3413" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->