### PR TITLE
fix: stabilize frigate live view

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -113,7 +113,7 @@ spec:
       shm:
         type: emptyDir
         medium: Memory
-        sizeLimit: 128Mi
+        sizeLimit: 256Mi
         globalMounts:
           - path: /dev/shm
 

--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -60,11 +60,11 @@ go2rtc:
       - "ffmpeg:birdy#audio=aac"
       - "ffmpeg:birdy#audio=opus"
     birdy_live:
-      - "ffmpeg:birdy#video=h264"
+      - "ffmpeg:birdy#video=h264#audio=aac/16000"
     birdy_sub:
       - rtsp://192.168.1.180:8554/sub
     birdy_sub_live:
-      - "ffmpeg:birdy_sub#video=h264"
+      - "ffmpeg:birdy_sub#video=h264#audio=aac/16000"
 
 cameras:
   birdy:

--- a/kubernetes/apps/home-automation/frigate/app/config.yml
+++ b/kubernetes/apps/home-automation/frigate/app/config.yml
@@ -50,17 +50,21 @@ objects:
   track: ["bird"]
 
 go2rtc:
+  ffmpeg:
+    h264: >-
+      -vf format=yuv420p -codec:v h264_rkmpp -profile:v main -level:v 41
+      -g:v 15 -r 15 -bf:v 0
   streams:
     birdy:
       - rtsp://192.168.1.180:8554/main
       - "ffmpeg:birdy#audio=aac"
       - "ffmpeg:birdy#audio=opus"
     birdy_live:
-      - "ffmpeg:birdy#video=copy#audio=aac"
+      - "ffmpeg:birdy#video=h264"
     birdy_sub:
       - rtsp://192.168.1.180:8554/sub
     birdy_sub_live:
-      - "ffmpeg:birdy_sub#video=copy#audio=aac"
+      - "ffmpeg:birdy_sub#video=h264"
 
 cameras:
   birdy:


### PR DESCRIPTION
## Summary
- keep Frigate live view on a clean H.264 re-encode for browser stability
- restore live audio as AAC-LC from the camera G.711 source
- increase Frigate /dev/shm from 128Mi to 256Mi to clear the startup warning

## Verification
- task k8s:kubeconform
- applied only the HelmRelease SHM change to the live cluster and reconciled the Frigate HelmRelease
- Frigate deployment rolled out successfully
- /dev/shm inside the Frigate pod now reports 256M
- startup logs no longer show the Frigate shared-memory warning

## Notes
- The SHM live apply intentionally targeted only HelmRelease.yaml, not the app kustomization, to avoid reapplying unrelated ConfigMap state while checking this change.