### PR TITLE
fix: preserve rustfs bucket job env

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -2,8 +2,10 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rustfs-buckets-create-v2
+  name: rustfs-buckets-create-v3
   namespace: storage
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   backoffLimit: 6
   ttlSecondsAfterFinished: 3600


### PR DESCRIPTION
## Summary
- prevent Flux postBuild substitution from blanking runtime shell env vars in the RustFS bucket Job
- bump the bucket Job to v3 so Flux creates a fresh immutable Job template

## Verification
- git diff --check
- task kubernetes:kubeconform

## Live check
- RustFS is running as UID 977/GID 988 and can write to /data
- Loki has no recent RustFS/S3 permission failures
- Existing rustfs-buckets-create-v2 Job is broken because its rendered args contain empty env values