### PR TITLE
fix: allow vmagent to scrape dragonfly

### DIFF
--- a/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cluster.yaml
+  - ./networkpolicy.yaml
   - ./podmonitor.yaml

--- a/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/networkpolicy.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dragonfly-vmagent-metrics
+spec:
+  podSelector:
+    matchLabels:
+      app: dragonfly
+      app.kubernetes.io/name: dragonfly
+      app.kubernetes.io/part-of: dragonfly
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: vmagent
+              app.kubernetes.io/instance: vm
+      ports:
+        - port: 9999
+          protocol: TCP


### PR DESCRIPTION
## Summary
- add an additive NetworkPolicy for Dragonfly metrics access from monitoring/vmagent
- include the policy in the Dragonfly cluster kustomization
- pruned the stale live-only unpoller VMServiceScrape that was still feeding vmagent an empty scrape pool

## Verification
- task kubernetes:kubeconform
- kubectl exec -n monitoring deploy/vmagent-vm -- wget -qO- --timeout=5 http://10.69.12.177:9999/metrics
- vmagent targets show podScrape/database/dragonfly/0 as 1/1 up
- task kubernetes:alerts no longer reports TargetDown