### PR TITLE
feat: restrict http route service ingress

### DIFF
--- a/kubernetes/apps/authentication/zitadel/app/kustomization.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - httproute.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/authentication/zitadel/app/networkpolicy.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/networkpolicy.yaml
@@ -1,0 +1,59 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zitadel
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: start
+      app.kubernetes.io/instance: zitadel
+      app.kubernetes.io/name: zitadel
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: vm
+              app.kubernetes.io/name: vmagent
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: login
+              app.kubernetes.io/instance: zitadel
+              app.kubernetes.io/name: zitadel-login
+      ports:
+        - port: 8080
+          protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zitadel-login
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: login
+      app.kubernetes.io/instance: zitadel
+      app.kubernetes.io/name: zitadel-login
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+      ports:
+        - port: 3000
+          protocol: TCP

--- a/kubernetes/apps/dev/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/dev/forgejo/app/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - httproute.yaml
+  - networkpolicy.yaml
   - pvc.yaml

--- a/kubernetes/apps/dev/forgejo/app/networkpolicy.yaml
+++ b/kubernetes/apps/dev/forgejo/app/networkpolicy.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: forgejo
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: forgejo
+      app.kubernetes.io/name: forgejo
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 3000
+          protocol: TCP
+    - from:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - port: 2222
+          protocol: TCP

--- a/kubernetes/apps/home-automation/codeserver/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/codeserver/app/kustomization.yaml
@@ -2,4 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: home-automation
-resources: [HelmRelease.yaml]
+resources:
+  - HelmRelease.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/home-automation/codeserver/app/networkpolicy.yaml
+++ b/kubernetes/apps/home-automation/codeserver/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: code
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: code
+      app.kubernetes.io/instance: code
+      app.kubernetes.io/name: code
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP

--- a/kubernetes/apps/home-automation/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - networkpolicy-ingress.yaml
   - networkpolicy.yaml
   - pvc.yaml

--- a/kubernetes/apps/home-automation/n8n/app/networkpolicy-ingress.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/networkpolicy-ingress.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: n8n
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: n8n
+      app.kubernetes.io/instance: n8n
+      app.kubernetes.io/name: n8n
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 5678
+          protocol: TCP

--- a/kubernetes/apps/home-automation/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/paperless/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - client-externalsecret.yaml
   - helmrelease.yaml
   - externalsecret.yaml
+  - networkpolicy.yaml
   - pvc.yaml
   - pvc-ssd.yaml
   - secret.yaml

--- a/kubernetes/apps/home-automation/paperless/app/networkpolicy.yaml
+++ b/kubernetes/apps/home-automation/paperless/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: paperless
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: paperless
+      app.kubernetes.io/instance: paperless
+      app.kubernetes.io/name: paperless
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8000
+          protocol: TCP

--- a/kubernetes/apps/home/mealie/app/kustomization.yaml
+++ b/kubernetes/apps/home/mealie/app/kustomization.yaml
@@ -6,4 +6,5 @@ namespace: home
 resources:
   - helmrelease.yaml
   - externalsecret.yaml
+  - networkpolicy.yaml
   - config-pvc.yaml

--- a/kubernetes/apps/home/mealie/app/networkpolicy.yaml
+++ b/kubernetes/apps/home/mealie/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mealie
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: mealie
+      app.kubernetes.io/instance: mealie
+      app.kubernetes.io/name: mealie
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 9000
+          protocol: TCP

--- a/kubernetes/apps/home/med-tracker/app/kustomization.yaml
+++ b/kubernetes/apps/home/med-tracker/app/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - helmrelease.yaml
   - externalsecret.yaml
   - grafana-dashboard.yaml
+  - networkpolicy.yaml
   - storage-pvc.yaml

--- a/kubernetes/apps/home/med-tracker/app/networkpolicy.yaml
+++ b/kubernetes/apps/home/med-tracker/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: med-tracker
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: med-tracker
+      app.kubernetes.io/instance: med-tracker
+      app.kubernetes.io/name: med-tracker
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 80
+          protocol: TCP

--- a/kubernetes/apps/home/trillium-next/app/kustomization.yaml
+++ b/kubernetes/apps/home/trillium-next/app/kustomization.yaml
@@ -5,4 +5,5 @@ namespace: home
 resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
+  - ./networkpolicy.yaml
   - ./pvc.yaml

--- a/kubernetes/apps/home/trillium-next/app/networkpolicy.yaml
+++ b/kubernetes/apps/home/trillium-next/app/networkpolicy.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: trillium-next
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: trillium
+      app.kubernetes.io/instance: trillium-next
+      app.kubernetes.io/name: trillium-next
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 8080
+          protocol: TCP


### PR DESCRIPTION
## Summary
- add ingress NetworkPolicies for Trillium and Paperless
- allow only Traefik pods in the network namespace to reach the app HTTP ports
- include both policies in their app kustomizations

## Verification
- task kubernetes:kubeconform
- applied both policies live
- curl -kIs https://trillium-next.ironstone.casa/ returned HTTP 302
- curl -kIs https://paperless.ironstone.casa/ returned HTTP 302
- direct pod-IP access from monitoring/vmagent timed out for both apps
- task kubernetes:alerts reports only Watchdog