### PR TITLE
feat: scaffold oidc forward auth

### DIFF
--- a/kubernetes/apps/authentication/kustomization.yaml
+++ b/kubernetes/apps/authentication/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./namespace.yaml
+  - ./oauth2-proxy/ks.yaml
   - ./zitadel-db/ks.yaml
   - ./zitadel/ks.yaml

--- a/kubernetes/apps/authentication/oauth2-proxy/README.md
+++ b/kubernetes/apps/authentication/oauth2-proxy/README.md
@@ -1,0 +1,28 @@
+# OAuth2 Proxy Forward Auth
+
+This deploys a shared OAuth2 Proxy instance for Traefik `ForwardAuth` using Zitadel as the OIDC provider.
+
+Before reconciling, create a 1Password item named `zitadel-oauth2-proxy-oidc` with:
+
+- `client_id`
+- `client_secret`
+- `cookie_secret`
+
+The Zitadel app redirect URI should be:
+
+```text
+https://auth.ironstone.casa/oauth2/callback
+```
+
+To protect an app later, add a Traefik `ExtensionRef` filter to that app's `HTTPRoute` rule. The middleware must exist in the same namespace as the `HTTPRoute`; this scaffold creates `oauth2-proxy-forward-auth` and `oauth2-proxy-auth-only` in the likely app namespaces.
+
+```yaml
+filters:
+  - type: ExtensionRef
+    extensionRef:
+      group: traefik.io
+      kind: Middleware
+      name: oauth2-proxy-forward-auth
+```
+
+Use `oauth2-proxy-forward-auth` for browser apps that should redirect to Zitadel. Use `oauth2-proxy-auth-only` for API paths that should return `401` instead of redirecting.

--- a/kubernetes/apps/authentication/oauth2-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oauth2-proxy
+  namespace: authentication
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: oauth2-proxy
+    template:
+      engineVersion: v2
+      data:
+        OAUTH2_PROXY_CLIENT_ID: "{{ .client_id }}"
+        OAUTH2_PROXY_CLIENT_SECRET: "{{ .client_secret }}"
+        OAUTH2_PROXY_COOKIE_SECRET: "{{ .cookie_secret }}"
+  dataFrom:
+    - extract:
+        key: zitadel-oauth2-proxy-oidc

--- a/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
@@ -1,0 +1,106 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: authentication
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  uninstall:
+    keepHistory: false
+  values:
+    controllers:
+      oauth2-proxy:
+        replicas: 2
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.2
+            envFrom:
+              - secretRef:
+                  name: oauth2-proxy
+            args:
+              - --http-address=0.0.0.0:4180
+              - --provider=oidc
+              - --oidc-issuer-url=https://zitadel.damacus.io
+              - --redirect-url=https://auth.ironstone.casa/oauth2/callback
+              - --email-domain=*
+              - --scope=openid profile email groups
+              - --cookie-domain=.ironstone.casa
+              - --whitelist-domain=.ironstone.casa
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --cookie-refresh=1h
+              - --cookie-expire=8h
+              - --cookie-csrf-per-request=true
+              - --cookie-csrf-expire=5m
+              - --reverse-proxy=true
+              - --set-xauthrequest=true
+              - --set-authorization-header=true
+              - --pass-access-token=true
+              - --pass-authorization-header=true
+              - --skip-provider-button=true
+              - --upstream=static://202
+              - --standard-logging=true
+              - --request-logging=true
+              - --auth-logging=true
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: &port 4180
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+        pod:
+          securityContext:
+            runAsUser: 2000
+            runAsGroup: 2000
+            runAsNonRoot: true
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        controller: oauth2-proxy
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/authentication/oauth2-proxy/app/httproute.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/httproute.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oauth2-proxy
+  namespace: authentication
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "traefik-int.ironstone.casa"
+spec:
+  hostnames:
+    - auth.ironstone.casa
+  parentRefs:
+    - name: traefik-internal
+      namespace: network
+      sectionName: websecure
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          name: oauth2-proxy
+          port: 4180

--- a/kubernetes/apps/authentication/oauth2-proxy/app/kustomization.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./middlewares.yaml

--- a/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
@@ -1,0 +1,171 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/traefik.io/middleware_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-forward-auth
+  namespace: home-automation
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth-only
+  namespace: home-automation
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-forward-auth
+  namespace: home
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth-only
+  namespace: home
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-forward-auth
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth-only
+  namespace: monitoring
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-forward-auth
+  namespace: storage
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth-only
+  namespace: storage
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-forward-auth
+  namespace: kube-system
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: oauth2-proxy-auth-only
+  namespace: kube-system
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User

--- a/kubernetes/apps/authentication/oauth2-proxy/ks.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oauth2-proxy
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/authentication/oauth2-proxy/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  dependsOn:
+    - name: external-secrets-stores
+    - name: traefik
+    - name: zitadel

--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -78,7 +78,7 @@ spec:
         controller: frigate
         ports:
           http:
-            port: *api_port
+            port: 8971
           rtsp:
             port: 8554
 

--- a/kubernetes/apps/network/traefik/app/HelmRelease.yaml
+++ b/kubernetes/apps/network/traefik/app/HelmRelease.yaml
@@ -10,10 +10,12 @@ spec:
     kind: OCIRepository
     name: traefik
   install:
+    crds: Create
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
+    crds: CreateReplace
     remediation:
       strategy: rollback
       retries: 3


### PR DESCRIPTION
## Summary
- add a shared oauth2-proxy deployment scaffold for Zitadel-backed Traefik forward auth
- add per-namespace Traefik Middleware scaffolding without attaching it to app routes yet
- configure Traefik HelmRelease to install and upgrade its CRDs
- move Frigate's routed service port to 8971 while leaving health checks on 5000

## Verification
- task kubernetes:kubeconform
- kustomize build kubernetes/apps/authentication/oauth2-proxy/app
- kustomize build kubernetes/apps/authentication
- kustomize build kubernetes/apps/network/traefik/app