### PR TITLE
fix: manage gateway api crds with flux

### DIFF
--- a/kubernetes/apps/network/gateway-api-crds/ks.yaml
+++ b/kubernetes/apps/network/gateway-api-crds/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: gateway-api
+  namespace: flux-system
+spec:
+  interval: 1h
+  ref:
+    # renovate: depName=kubernetes-sigs/gateway-api datasource=github-releases versioning=semver-coerced
+    tag: v1.5.1
+  url: https://github.com/kubernetes-sigs/gateway-api.git
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gateway-api-crds
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./config/crd/standard
+  prune: false # never delete cluster-scoped CRDs during source changes
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: gateway-api
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./echo-server/ks.yaml
   - ./external-dns/ks.yaml
   - ./external-services/ks.yaml
+  - ./gateway-api-crds/ks.yaml
   - ./traefik/ks.yaml

--- a/kubernetes/apps/network/traefik/app/HelmRelease.yaml
+++ b/kubernetes/apps/network/traefik/app/HelmRelease.yaml
@@ -10,12 +10,12 @@ spec:
     kind: OCIRepository
     name: traefik
   install:
-    crds: Create
+    crds: Skip
     remediation:
       retries: 3
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
+    crds: Skip
     remediation:
       strategy: rollback
       retries: 3
@@ -34,7 +34,7 @@ spec:
         allowEmptyServices: true
       kubernetesGateway:
         enabled: true
-        experimentalChannel: true
+        experimentalChannel: false
 
     # Gateway configuration
     gateway:

--- a/kubernetes/apps/network/traefik/ks.yaml
+++ b/kubernetes/apps/network/traefik/ks.yaml
@@ -11,6 +11,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: gateway-api-crds
     - name: certificates
   path: ./kubernetes/apps/network/traefik/app
   prune: true


### PR DESCRIPTION
## Summary
- Add a Flux-managed Gateway API CRD source pinned to v1.5.1.
- Make Traefik depend on the CRD fixture and stop Helm from owning Gateway API CRDs.
- Disable Traefik Gateway API experimental channel so the standard CRD bundle is sufficient.

## Validation
- kubectl kustomize kubernetes/apps/network
- task k8s:kubeconform