### PR TITLE
fix: restore frigate traefik backend

### DIFF
--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -78,7 +78,7 @@ spec:
         controller: frigate
         ports:
           http:
-            port: 8971
+            port: *api_port
           rtsp:
             port: 8554
 


### PR DESCRIPTION
## Summary
- route Frigate's Traefik-facing service back to the internal HTTP API port
- avoid sending Gateway traffic to Frigate's HTTPS/auth port, which was returning backend errors

## Verification
- git diff --check
- pre-commit hooks during commit
- verified in-cluster Traefik request to /api/version returned 200 OK with Frigate 0.17.1-416a9b7