### PR TITLE
fix(memos): use numeric probe ports

### DIFF
--- a/kubernetes/apps/home/memos/app/helmrelease.yaml
+++ b/kubernetes/apps/home/memos/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
               MEMOS_DATA: &datadir /var/opt/memos
               MEMOS_DRIVER: sqlite
               MEMOS_INSTANCE_URL: https://notes.ironstone.casa
-              MEMOS_PORT: &port "5230"
+              MEMOS_PORT: "5230"
             probes:
               liveness:
                 enabled: true
@@ -46,14 +46,14 @@ spec:
                 spec:
                   httpGet:
                     path: /
-                    port: *port
+                    port: 5230
               readiness:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /
-                    port: *port
+                    port: 5230
               startup:
                 enabled: false
             resources:
@@ -81,7 +81,7 @@ spec:
         controller: memos
         ports:
           http:
-            port: *port
+            port: 5230
 
     route:
       app:


### PR DESCRIPTION
## Summary
- keep MEMOS_PORT as a string env value
- render Memos readiness/liveness and Service ports as numeric values so Kubernetes accepts the Deployment

## Verification
- yq type assertions for liveness, readiness, service port, and env port
- task k8s:kubeconform
- live HelmRelease reconciliation after applying patched manifest