### PR TITLE
fix(helm): pin cloudnative-pg to published chart version

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: 0.28.1
+      version: 0.28.0
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg


### PR DESCRIPTION
## Summary
- revert CloudNativePG chart pin from nonexistent 0.28.1 to published 0.28.0
- unblocks Flux reconciliation for CloudNativePG and dependent database workloads

## Verification
- task k8s:kubeconform
- flux reconcile helmrelease cloudnative-pg -n database --with-source

Note: task flux:local-test path=./kubernetes/apps/database/cloudnative-pg could not run in this Codex worktree because the flux-local container cannot resolve the external Git worktree metadata path.