### PR TITLE
fix(helm): restore cloudnative-pg 0.28.1

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: 0.28.0
+      version: 0.28.1
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg


### PR DESCRIPTION
## Summary
- restore the CloudNativePG chart pin to 0.28.1 now that the upstream Helm index contains it
- keeps Git aligned with the live cluster after forcing the HelmRepository and HelmRelease reconciliation

## Verification
- live HelmRepository fetched index revision sha256:bb8d83211b2cb2f2c3f74641427130e99c54e429ad72e8603dc80909772ac8a2
- flux reconcile helmrelease cloudnative-pg -n database --with-source
- commit hooks: yamllint and Kubernetes secret scan passed