### PR TITLE
fix(reflector): mirror cnpg rustfs credentials

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
   - ./metrics-server/ks.yaml
   - ./node-feature-discovery/ks.yaml
   - ./reloader/ks.yaml
-  # - ./reflector/ks.yaml
+  - ./reflector/namespace.yaml
+  - ./reflector/ks.yaml

--- a/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   interval: 1h
   url: oci://ghcr.io/emberstack/helm-charts/reflector
-  # ref:
-  #   tag: v9.1.32
+  ref:
+    tag: 10.0.16
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
## Summary
- enable the reflector Kustomization and its namespace
- pin reflector's OCI chart to 10.0.16 because the upstream chart repository has no latest tag
- restores automatic mirroring of rustfs-cnpg-credentials into CNPG workload namespaces

## Verification
- task k8s:kubeconform
- live reflector HelmRelease installed successfully with chart reflector@10.0.16
- rustfs-cnpg-credentials exists in authentication, dev, home, and home-automation