### PR TITLE
fix(minio): restore healthy ironbuckets rollout

### DIFF
--- a/kubernetes/apps/storage/minio/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/minio/app/helmrelease.yaml
@@ -28,14 +28,6 @@ spec:
         replicas: 1
         annotations:
           reloader.stakater.com/auto: "true"
-        pod:
-          securityContext:
-            runAsUser: 1000
-            runAsGroup: 1000
-            runAsNonRoot: true
-            fsGroup: 1000
-            fsGroupChangePolicy: OnRootMismatch
-            seccompProfile: { type: RuntimeDefault }
         containers:
           app:
             image:
@@ -76,14 +68,10 @@ spec:
               limits:
                 cpu: 1000m
                 memory: 2Gi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop: ["ALL"]
           ironbuckets:
             image:
               repository: ghcr.io/damacus/ironbuckets
-              tag: 1.4.3
+              tag: 1.3.0
             env:
               MINIO_ENDPOINT: "localhost:9000"
             probes:
@@ -116,10 +104,6 @@ spec:
               limits:
                 cpu: 500m
                 memory: 512Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop: ["ALL"]
     service:
       main:
         controller: main


### PR DESCRIPTION
## Summary
- pin MinIO's ironbuckets sidecar back to the last healthy image
- revert MinIO-specific workload hardening values that make the ironbuckets entrypoint non-executable

## Verification
- task k8s:kubeconform
- flux check
- kubectl get kustomizations.kustomize.toolkit.fluxcd.io -A
- kubectl get helmreleases.helm.toolkit.fluxcd.io -A