### PR TITLE
fix: add Resend SMTP config to med-tracker

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
@@ -29,6 +29,10 @@ spec:
           able"
         OIDC_CLIENT_ID: "{{ .client_id }}"
         OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+        SMTP_ADDRESS: "smtp.resend.com"
+        SMTP_USER_NAME: "resend"
+        SMTP_PASSWORD: "{{ .RESEND_API_KEY }}"
+        MAILER_FROM: "MedTracker <notifications@damacus.io>"
   dataFrom:
     - extract:
         key: med-tracker


### PR DESCRIPTION
- Add SMTP_ADDRESS, SMTP_USER_NAME, SMTP_PASSWORD, MAILER_FROM

- Reuses existing RESEND_API_KEY from 1Password
