### PR TITLE
fix: wire penpot secrets

### DIFF
--- a/kubernetes/apps/home/penpot-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home/penpot-db/app/scheduledbackup.yaml
@@ -13,6 +13,6 @@ spec:
   pluginConfiguration:
     name: barman-cloud.cloudnative-pg.io
     parameters:
-      objectStore: penpot-minio-store
+      objectStore: penpot-rustfs-store
   cluster:
     name: penpot

--- a/kubernetes/apps/home/penpot/app/externalsecret.yaml
+++ b/kubernetes/apps/home/penpot/app/externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
     - secretKey: secret-key
       remoteRef:
         key: penpot
-        property: secret_key
+        property: api_secret_key
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 # Zitadel OIDC credentials

--- a/kubernetes/apps/home/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/home/penpot/app/helmrelease.yaml
@@ -202,6 +202,11 @@ spec:
               # Exporter loads pages via headless Chromium; use the internal frontend service
               PENPOT_PUBLIC_URI: http://penpot-frontend.home.svc.cluster.local
               PENPOT_BROWSER_CONFIG: --no-sandbox --disable-dev-shm-usage
+              PENPOT_SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: penpot-secret
+                    key: secret-key
             probes:
               liveness:
                 enabled: false


### PR DESCRIPTION
## Summary
- point Penpot ExternalSecret at the existing api_secret_key field
- pass PENPOT_SECRET_KEY into the Penpot exporter
- use the RustFS ObjectStore for Penpot database backups

## Verification
- task k8s:kubeconform
- pre-commit hooks during git commit