### PR TITLE
fix: group penpot renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,18 @@
   ],
   packageRules: [
     {
+      description: "Group and auto-merge non-major Penpot container updates",
+      groupName: "penpot containers",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "penpotapp/backend",
+        "penpotapp/exporter",
+        "penpotapp/frontend",
+      ],
+      matchUpdateTypes: ["digest", "minor", "patch", "pin", "pinDigest"],
+      automerge: true,
+    },
+    {
       description: "Auto-merge non-major updates for selected home-ops assets",
       matchPackageNames: [
         "ghcr.io/coder/code-server",


### PR DESCRIPTION
## Summary
- group Penpot backend, exporter, and frontend Docker updates into one Renovate PR
- allow non-major Penpot container updates to automerge

## Verification
- git diff --check
- parsed .github/renovate.json5 as a JavaScript object literal