### PR TITLE
Update Renovate workflow to use create-github-app-token client-id

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
+          client-id: "${{ secrets.BOT_APP_ID }}"
           private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
 
       - name: Checkout


### PR DESCRIPTION
## Summary
- Replace the deprecated `app-id` input with `client-id` in the Renovate GitHub App token step
- Keep the existing `BOT_APP_ID` secret wiring intact

## Testing
- Not run (not requested)
- Verified the workflow diff is limited to the token input name change