### PR TITLE
fix: set MedTracker timezone

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
                   name: med-tracker-secret
             env:
               RAILS_ENV: production
+              TZ: Europe/London
         containers:
           app:
             image:
@@ -61,6 +62,7 @@ spec:
                   name: med-tracker-secret
             env:
               RAILS_ENV: production
+              TZ: Europe/London
               RAILS_FORCE_SSL: "false"
               RAILS_LOG_LEVEL: info
               SOLID_QUEUE_IN_PUMA: "true"


### PR DESCRIPTION
## Summary
- set TZ=Europe/London for the MedTracker migration init container
- set TZ=Europe/London for the MedTracker app container

## Verification
- pre-commit manifest hooks passed during commit