### PR TITLE
fix(n8n): restrict public webhook route paths

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -184,7 +184,13 @@ spec:
           - matches:
               - path:
                   type: PathPrefix
-                  value: /
+                  value: /webhook
+              - path:
+                  type: PathPrefix
+                  value: /webhook-test
+              - path:
+                  type: PathPrefix
+                  value: /webhook-waiting
             backendRefs:
               - kind: Service
                 name: n8n


### PR DESCRIPTION
### Motivation
- A public HTTPRoute for `n8n-webhooks.damacus.io` matched `PathPrefix: /`, exposing the full n8n UI/API/first-run setup to the Internet and allowing potential owner account takeover on fresh DBs. 
- The intent of this change is to close the attack surface by limiting the public webhook hostname to only webhook endpoints while preserving internal access for the main application host.

### Description
- Replaced the public webhook HTTPRoute path match in `kubernetes/apps/home-automation/n8n/app/helmrelease.yaml` so it no longer uses `PathPrefix: /` and now only matches `/webhook`, `/webhook-test`, and `/webhook-waiting`.
- The internal `app` route for `n8n.ironstone.casa` remains unchanged so in-cluster/internal UI/API access is preserved.
- The change is intentionally minimal and declarative to avoid reintroducing functionality that previously exposed the admin/setup surface publicly.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it succeeded.
- Reviewed the resulting stanza with `git diff -- kubernetes/apps/home-automation/n8n/app/helmrelease.yaml` to validate the path restrictions were applied.
- Committed the change as `fix(n8n): restrict public webhook route paths` and verified the modified file at `kubernetes/apps/home-automation/n8n/app/helmrelease.yaml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05eca8a65c8322a0768625d8da31b3)