### PR TITLE
fix: map Grafana OnCall secrets explicitly

### DIFF
--- a/.taskfiles/Flux/Taskfile.yaml
+++ b/.taskfiles/Flux/Taskfile.yaml
@@ -92,6 +92,6 @@ tasks:
 
       Args:
         path: Path to build (default: ./kubernetes)
-    cmd: bash {{.ROOT_DIR}}/scripts/flux-local-container.sh build --enable-helm --api-versions "policy/v1/PodDisruptionBudget,monitoring.coreos.com/v1,monitoring.coreos.com/v1/ServiceMonitor,monitoring.coreos.com/v1/PodMonitor,monitoring.coreos.com/v1/PrometheusRule" --path {{.path}}
+    cmd: bash {{.ROOT_DIR}}/scripts/flux-local-build.sh {{.path}}
     vars:
       path: '{{.path | default "./kubernetes"}}'

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -4,6 +4,7 @@ version: "3"
 
 vars:
   KUBECONFORM_SCRIPT: "{{.SCRIPTS_DIR}}/kubeconform.sh"
+  CLUSTER_HEALTH_SCRIPT: "{{.SCRIPTS_DIR}}/cluster-health.py"
 
 tasks:
   resources:
@@ -26,6 +27,102 @@ tasks:
   check-kube-vip:
     desc: Check all kube-vip pods
     cmd: kubectl get pods -n kube-system -l app.kubernetes.io/name=kube-vip -o wide
+
+  health:
+    desc: Run read-only cluster health checks
+    summary: |
+      Checks nodes, kube-vip, Cilium, active pod readiness, deployment
+      availability, CNPG cluster state, and firing Grafana/Prometheus alerts.
+
+      Examples:
+        task kubernetes:health
+        task kubernetes:health json=true
+        task kubernetes:health notify=true
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NOTIFY: '{{.notify | default "false"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.CLUSTER_HEALTH_SCRIPT}} health
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NOTIFY "true"}}--notify{{end}}
+    preconditions:
+      - { msg: "Missing Python interpreter", sh: "command -v {{.PYTHON_BIN}} >/dev/null" }
+      - { msg: "Missing cluster health script", sh: "test -f {{.CLUSTER_HEALTH_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
+
+  cnpg-health:
+    desc: Check all CNPG clusters for healthy ready state
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NOTIFY: '{{.notify | default "false"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.CLUSTER_HEALTH_SCRIPT}} cnpg-health
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NOTIFY "true"}}--notify{{end}}
+    preconditions:
+      - { msg: "Missing cluster health script", sh: "test -f {{.CLUSTER_HEALTH_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
+
+  cnpg-backups:
+    desc: Check CNPG backup resources and WAL archiving status
+    summary: |
+      Summarizes latest Backup resources, latest successful backups, and
+      kubectl cnpg status WAL archiving health for every CNPG cluster.
+
+      Examples:
+        task kubernetes:cnpg-backups
+        task kubernetes:cnpg-backups notify=true
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NOTIFY: '{{.notify | default "false"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.CLUSTER_HEALTH_SCRIPT}} cnpg-backups
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NOTIFY "true"}}--notify{{end}}
+    preconditions:
+      - { msg: "Missing cluster health script", sh: "test -f {{.CLUSTER_HEALTH_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
+
+  grafana-alerts:
+    desc: Check firing Grafana/Prometheus and Alertmanager alerts
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NOTIFY: '{{.notify | default "false"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.CLUSTER_HEALTH_SCRIPT}} grafana-alerts
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NOTIFY "true"}}--notify{{end}}
+    preconditions:
+      - { msg: "Missing cluster health script", sh: "test -f {{.CLUSTER_HEALTH_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
+
+  morning-check:
+    desc: Run the recurring morning cluster health bundle
+    summary: |
+      Runs the regular operator checks: cluster core health, CNPG clusters,
+      CNPG backups/WAL archiving, firing alerts, and edge smoke. Log-noise can
+      be included with log_noise=true.
+
+      Examples:
+        task kubernetes:morning-check
+        task kubernetes:morning-check notify=true
+        task kubernetes:morning-check log_noise=true period=6h top=10
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NOTIFY: '{{.notify | default "false"}}'
+      LOG_NOISE: '{{.log_noise | default "false"}}'
+      PERIOD: '{{.period | default "1h"}}'
+      TOP: '{{.top | default "20"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.CLUSTER_HEALTH_SCRIPT}} morning-check
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NOTIFY "true"}}--notify{{end}}
+      {{if eq .LOG_NOISE "true"}}--log-noise{{end}}
+      --period {{.PERIOD}}
+      --top {{.TOP}}
+    preconditions:
+      - { msg: "Missing cluster health script", sh: "test -f {{.CLUSTER_HEALTH_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
 
   kubeconform:
     desc: Validate Kubernetes manifests with kubeconform

--- a/.taskfiles/Unifi/Taskfile.yaml
+++ b/.taskfiles/Unifi/Taskfile.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  UNIFI_READ_STATUS_SCRIPT: "{{.ROOT_DIR}}/scripts/unifi/read-status.py"
+
+tasks:
+  mesh-status:
+    desc: Read UniFi mesh/backhaul state for the garage camera path
+    summary: |
+      Read-only UniFi diagnostic for the U6-LR <-> U6-Mesh backhaul and the
+      downstream USW-Lite/Garage camera path. The script reads the UniFi API
+      key from the existing Kubernetes secret and prints device state, AP radio
+      settings, active wireless uplinks, mesh peer observations, switch ports,
+      client matches, and ICMP reachability.
+
+      Examples:
+        task unifi:mesh-status
+        task unifi:mesh-status json=true
+        task unifi:mesh-status no_ping=true
+        task unifi:mesh-status devices=U6-LR,U6-Mesh,U6\\ Pro
+    vars:
+      JSON: '{{.json | default "false"}}'
+      NO_PING: '{{.no_ping | default "false"}}'
+      DEVICES: '{{.devices | default "U6-LR,U6-Mesh,U6 Pro,USW-Lite-8-PoE"}}'
+      WATCH_IPS: '{{.watch_ips | default "U6-LR=192.168.1.155,U6-Mesh=192.168.1.109,USW-Lite-8-PoE=192.168.1.38,Garage=192.168.1.168"}}'
+      CLIENT_MACS: '{{.client_macs | default "70:a7:41:5f:13:d9"}}'
+    cmd: >-
+      {{.PYTHON_BIN}} {{.UNIFI_READ_STATUS_SCRIPT}}
+      --devices "{{.DEVICES}}"
+      --watch-ips "{{.WATCH_IPS}}"
+      --client-macs "{{.CLIENT_MACS}}"
+      {{if eq .JSON "true"}}--json{{end}}
+      {{if eq .NO_PING "true"}}--no-ping{{end}}
+    preconditions:
+      - { msg: "Missing Python interpreter", sh: "command -v {{.PYTHON_BIN}} >/dev/null" }
+      - { msg: "Missing UniFi read status script", sh: "test -f {{.UNIFI_READ_STATUS_SCRIPT}}" }
+      - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -46,6 +46,7 @@ includes:
   postgres:
     aliases: ["pg"]
     taskfile: .taskfiles/Postgres/Taskfile.yaml
+  unifi: .taskfiles/Unifi/Taskfile.yaml
 
 tasks:
   default: task -l

--- a/docs/ESCALATION-POLICIES-SETUP.md
+++ b/docs/ESCALATION-POLICIES-SETUP.md
@@ -11,10 +11,11 @@ This document describes the implementation of Do-Not-Disturb (DND) aware escalat
 The home-ops cluster uses:
 
 - **Alertmanager** (via VictoriaMetrics stack) for alert routing
-- **Pushover** for notifications (not Grafana Cloud OnCall)
+- **Grafana Cloud OnCall** as the primary destination for actionable alerts
+- **Pushover** as a rollout fallback notification path
 - **ExternalSecret** to manage Alertmanager config from 1Password
 
-**Important**: The epic `home-ops-cil` describes deploying a self-hosted Grafana OnCall, but the current setup uses Grafana Cloud OnCall (external SaaS). Escalation policies must be configured in Alertmanager, not in OnCall itself.
+**Important**: The epic `home-ops-cil` describes deploying a self-hosted Grafana OnCall, but the current setup uses Grafana Cloud OnCall / IRM. Routing and DND policy stay in Alertmanager; OnCall handles paging and escalation after Alertmanager sends the webhook.
 
 ### 2. DND Implementation Strategy
 
@@ -159,7 +160,7 @@ This project uses:
 
 - **home-ops-qyh**: Configure escalation policies and notification channels (COMPLETED)
 - **home-ops-cil**: Grafana On-Call: Core Setup & Configuration (PARENT EPIC)
-- **home-ops-uw0**: Integrate Alertmanager with On-Call (BLOCKED)
+- **home-ops-uw0**: Integrate Alertmanager with On-Call
 
 ## References
 

--- a/docs/GRAFANA-ONCALL-SETUP.md
+++ b/docs/GRAFANA-ONCALL-SETUP.md
@@ -1,0 +1,73 @@
+# Grafana Cloud OnCall Setup
+
+## Overview
+
+Grafana Cloud OnCall is the primary destination for actionable Alertmanager alerts. Pushover remains in the same Alertmanager receivers during rollout so alerts still produce the existing mobile signal while OnCall paging is verified.
+
+The local Grafana instance is managed through GitOps. Do not treat manual Grafana UI changes as authoritative; update the manifests and 1Password items instead.
+
+## Required 1Password Fields
+
+The `grafana-cloud-oncall` item must expose these fields through External Secrets:
+
+- `credential`: Grafana OnCall plugin token, rendered into `GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN`.
+- `GRAFANA_ONCALL_ALERTMANAGER_URL`: Alertmanager integration webhook URL copied from Grafana Cloud OnCall. Keep the trailing slash.
+
+The Grafana OnCall plugin API URL is declared in `kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml`:
+
+```text
+https://oncall-prod-eu-west-0.grafana.net/oncall
+```
+
+## Grafana Cloud Setup
+
+1. In Grafana Cloud OnCall, create or open the `Alertmanager Prometheus` integration for this cluster.
+2. Copy the integration HTTP endpoint into the `GRAFANA_ONCALL_ALERTMANAGER_URL` field in the `grafana-cloud-oncall` 1Password item.
+3. Confirm the plugin token in `credential` is valid for the same Grafana Cloud OnCall stack.
+4. Let External Secrets refresh, or reconcile the relevant Flux resources.
+
+## Verification
+
+Run the static checks before applying changes:
+
+```bash
+task kubernetes:kubeconform
+task flux:local-build path=./kubernetes/apps/monitoring/grafana
+task flux:local-build path=./kubernetes/apps/monitoring/victoria-metrics
+```
+
+After Flux sync:
+
+```bash
+kubectl get secret grafana-oncall-secret -n monitoring
+kubectl get secret alertmanager-secret -n monitoring
+task kubernetes:grafana-alerts
+```
+
+In Grafana, verify:
+
+- `grafana-oncall-app` is installed and enabled.
+- Plugin settings use `https://oncall-prod-eu-west-0.grafana.net/oncall`.
+- The plugin token is present in secure JSON fields.
+- Grafana-managed alert policy routes to the `Alertmanager` contact point.
+
+In Alertmanager, verify:
+
+- Receivers `pushover` and `pushover-critical` include an OnCall webhook.
+- `Watchdog` still routes to Gatus heartbeat.
+- `InfoInhibitor` still routes to `null`.
+- Warning/info alerts still respect the DND mute intervals.
+- Critical alerts bypass DND.
+
+## End-to-End Test
+
+1. Fire a synthetic warning alert.
+2. Confirm it appears in Grafana Cloud OnCall and Pushover receives the rollout duplicate.
+3. Resolve the warning alert and confirm the OnCall alert group autoresolves.
+4. Fire a synthetic critical alert during a DND window.
+5. Confirm it pages through OnCall and still produces the critical Pushover notification.
+6. Resolve the critical alert and confirm the OnCall alert group autoresolves.
+
+## Rollback
+
+Remove the `webhook_configs` blocks from the `pushover` and `pushover-critical` receivers in `kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml`, then reconcile Flux. This returns routing to Pushover-only without changing Grafana dashboards or alert rules.

--- a/docs/GRAFANA-ONCALL-SETUP.md
+++ b/docs/GRAFANA-ONCALL-SETUP.md
@@ -10,8 +10,8 @@ The local Grafana instance is managed through GitOps. Do not treat manual Grafan
 
 The `grafana-cloud-oncall` item must expose these fields through External Secrets:
 
-- `credential`: Grafana OnCall plugin token, rendered into `GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN`.
-- `GRAFANA_ONCALL_ALERTMANAGER_URL`: Alertmanager integration webhook URL copied from Grafana Cloud OnCall. Keep the trailing slash.
+- `credential`: Grafana OnCall plugin token. Explicitly mapped to `GRAFANA_ONCALL_TOKEN`, then rendered into `GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN`.
+- `GRAFANA_ONCALL_ALERTMANAGER_URL`: Alertmanager integration webhook URL copied from Grafana Cloud OnCall. Explicitly mapped into the Alertmanager template. Treat this as sensitive.
 
 The Grafana OnCall plugin API URL is declared in `kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml`:
 

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -50,7 +50,7 @@ spec:
                   name: med-tracker-secret
             env:
               RAILS_ENV: production
-              TZ: Europe/London
+              TZ: "Europe/London"
         containers:
           app:
             image:
@@ -62,10 +62,10 @@ spec:
                   name: med-tracker-secret
             env:
               RAILS_ENV: production
-              TZ: Europe/London
               RAILS_FORCE_SSL: "false"
               RAILS_LOG_LEVEL: info
               SOLID_QUEUE_IN_PUMA: "true"
+              TZ: "Europe/London"
               APP_URL: "https://med-tracker.damacus.io"
               OIDC_ISSUER_URL: "https://zitadel.damacus.io"
               OIDC_REDIRECT_URI: "https://med-tracker.damacus.io/auth/oidc/callback"

--- a/kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_API_URL: "https://oncall-prod-eu-west-2.grafana.net/oncall"
+        GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_API_URL: "https://oncall-prod-eu-west-0.grafana.net/oncall"
         GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN: "{{ .credential }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/externalsecret-oncall.yaml
@@ -14,7 +14,9 @@ spec:
       engineVersion: v2
       data:
         GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_API_URL: "https://oncall-prod-eu-west-0.grafana.net/oncall"
-        GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN: "{{ .credential }}"
-  dataFrom:
-    - extract:
+        GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN: "{{ .GRAFANA_ONCALL_TOKEN }}"
+  data:
+    - secretKey: GRAFANA_ONCALL_TOKEN
+      remoteRef:
         key: grafana-cloud-oncall
+        property: credential

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
       GF_DATE_FORMATS_USE_BROWSER_LOCALE: true
       GF_EXPLORE_ENABLED: true
       GF_FEATURE_TOGGLES_ENABLE: publicDashboards
+      GF_PLUGINS_PREINSTALL_SYNC: grafana-oncall-app
       GF_SECURITY_COOKIE_SAMESITE: grafana
       GF_SERVER_ROOT_URL: https://grafana.ironstone.casa
     envFromSecrets:
@@ -89,6 +90,355 @@ spec:
                 type: prometheus-alertmanager
                 settings:
                   url: http://vmalertmanager-vm.monitoring.svc.cluster.local:9093
+      policies.yaml:
+        apiVersion: 1
+        policies:
+          - orgId: 1
+            receiver: Alertmanager
+            group_by:
+              - grafana_folder
+              - alertname
+            group_wait: 1m
+            group_interval: 10m
+            repeat_interval: 12h
+      rules.yaml:
+        apiVersion: 1
+        groups:
+          - orgId: 1
+            name: recurring-health
+            folder: Kubernetes
+            interval: 1m
+            rules:
+              - uid: cnpg-last-successful-backup-stale
+                title: CNPG last successful backup is stale
+                condition: C
+                data:
+                  - refId: A
+                    datasourceUid: prometheus
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    model:
+                      datasource:
+                        type: prometheus
+                        uid: prometheus
+                      editorMode: code
+                      expr: min by (namespace, job) (time() - cnpg_collector_last_available_backup_timestamp) > 90000
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: A
+                  - refId: B
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: A
+                      reducer: max
+                      refId: B
+                      type: reduce
+                  - refId: C
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: B
+                      refId: C
+                      type: threshold
+                noDataState: NoData
+                execErrState: Alerting
+                for: 15m
+                annotations:
+                  summary: CNPG backup age exceeds 25 hours
+                  description: At least one CNPG cluster has no recent successful backup.
+                labels:
+                  severity: critical
+              - uid: cnpg-recent-backup-failed
+                title: CNPG backup failed recently
+                condition: C
+                data:
+                  - refId: A
+                    datasourceUid: prometheus
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    model:
+                      datasource:
+                        type: prometheus
+                        uid: prometheus
+                      editorMode: code
+                      expr: max by (namespace, job) (time() - cnpg_collector_last_failed_backup_timestamp) < 3600
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: A
+                  - refId: B
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: A
+                      reducer: max
+                      refId: B
+                      type: reduce
+                  - refId: C
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: B
+                      refId: C
+                      type: threshold
+                noDataState: OK
+                execErrState: Alerting
+                for: 5m
+                annotations:
+                  summary: CNPG backup failed in the last hour
+                  description: A CNPG backup plugin run failed recently.
+                labels:
+                  severity: critical
+              - uid: cnpg-wal-archiving-failing
+                title: CNPG WAL archiving is failing
+                condition: C
+                data:
+                  - refId: A
+                    datasourceUid: prometheus
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    model:
+                      datasource:
+                        type: prometheus
+                        uid: prometheus
+                      editorMode: code
+                      expr: max by (namespace, job) ((cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1)
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: A
+                  - refId: B
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: A
+                      reducer: max
+                      refId: B
+                      type: reduce
+                  - refId: C
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: B
+                      refId: C
+                      type: threshold
+                noDataState: OK
+                execErrState: Alerting
+                for: 10m
+                annotations:
+                  summary: CNPG WAL archiving is failing
+                  description: A CNPG instance has a failed WAL newer than the last archived WAL.
+                labels:
+                  severity: critical
+              - uid: kube-crashlooping-pods
+                title: Kubernetes pods are crashlooping
+                condition: C
+                data:
+                  - refId: A
+                    datasourceUid: prometheus
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    model:
+                      datasource:
+                        type: prometheus
+                        uid: prometheus
+                      editorMode: code
+                      expr: sum by (namespace, pod, container, reason) (kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff"}) > 0
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: A
+                  - refId: B
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: A
+                      reducer: max
+                      refId: B
+                      type: reduce
+                  - refId: C
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: B
+                      refId: C
+                      type: threshold
+                noDataState: OK
+                execErrState: Alerting
+                for: 10m
+                annotations:
+                  summary: Kubernetes pod is crashlooping
+                  description: One or more containers are waiting in CrashLoopBackOff.
+                labels:
+                  severity: warning
+              - uid: kube-deployment-replicas-mismatch
+                title: Kubernetes deployment replicas mismatch
+                condition: C
+                data:
+                  - refId: A
+                    datasourceUid: prometheus
+                    relativeTimeRange:
+                      from: 600
+                      to: 0
+                    model:
+                      datasource:
+                        type: prometheus
+                        uid: prometheus
+                      editorMode: code
+                      expr: kube_deployment_spec_replicas != kube_deployment_status_replicas_available
+                      instant: true
+                      intervalMs: 1000
+                      maxDataPoints: 43200
+                      refId: A
+                  - refId: B
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: A
+                      reducer: max
+                      refId: B
+                      type: reduce
+                  - refId: C
+                    datasourceUid: __expr__
+                    relativeTimeRange:
+                      from: 0
+                      to: 0
+                    model:
+                      conditions:
+                        - evaluator:
+                            params:
+                              - 0
+                            type: gt
+                          operator:
+                            type: and
+                          query:
+                            params:
+                              - C
+                          reducer:
+                            params: []
+                            type: last
+                          type: query
+                      datasource:
+                        type: __expr__
+                        uid: __expr__
+                      expression: B
+                      refId: C
+                      type: threshold
+                noDataState: OK
+                execErrState: Alerting
+                for: 15m
+                annotations:
+                  summary: Kubernetes deployment replicas mismatch
+                  description: A deployment has fewer available replicas than desired.
+                labels:
+                  severity: warning
 
     dashboardProviders:
       dashboardproviders.yaml:
@@ -230,11 +580,13 @@ spec:
         apps:
           - type: grafana-oncall-app
             org_id: 1
-            enabled: true
+            disabled: false
             jsonData:
               stackId: 1
               orgId: 1
-              onCallApiUrl: $__env{GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_API_URL}
+              onCallApiUrl: $GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_API_URL
+            secureJsonData:
+              grafanaToken: $GF_PLUGIN_GRAFANA_ONCALL_APP_ONCALL_TOKEN
 
     serviceMonitor:
       enabled: true

--- a/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
@@ -158,6 +158,9 @@ spec:
     - extract:
         key: alertmanager
     - extract:
-        key: grafana-cloud-oncall
-    - extract:
         key: gatus
+  data:
+    - secretKey: GRAFANA_ONCALL_ALERTMANAGER_URL
+      remoteRef:
+        key: grafana-cloud-oncall
+        property: GRAFANA_ONCALL_ALERTMANAGER_URL

--- a/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
@@ -80,6 +80,10 @@ spec:
                       credentials: "{{ .GATUS_WATCHDOG_TOKEN }}"
             - name: "null"
             - name: pushover
+              webhook_configs:
+                - send_resolved: true
+                  max_alerts: 100
+                  url: "{{ .GRAFANA_ONCALL_ALERTMANAGER_URL }}"
               pushover_configs:
                 - html: true
                   message: |-
@@ -112,6 +116,10 @@ spec:
                   url_title: View in Alertmanager
                   user_key: "{{ .PUSHOVER_USER_KEY }}"
             - name: pushover-critical
+              webhook_configs:
+                - send_resolved: true
+                  max_alerts: 100
+                  url: "{{ .GRAFANA_ONCALL_ALERTMANAGER_URL }}"
               pushover_configs:
                 - html: true
                   message: |-
@@ -149,5 +157,7 @@ spec:
         key: pushover
     - extract:
         key: alertmanager
+    - extract:
+        key: grafana-cloud-oncall
     - extract:
         key: gatus

--- a/scripts/cluster-health.py
+++ b/scripts/cluster-health.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Read-only cluster health checks for recurring operator diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any, Final
+
+
+ALERT_QUERY: Final[str] = 'ALERTS{alertstate="firing",alertname!="Watchdog"}'
+PROMETHEUS_QUERY_URL: Final[str] = (
+    "http://vmsingle-vm.monitoring.svc.cluster.local:8428/api/v1/query?query={query}"
+)
+ALERTMANAGER_URL: Final[str] = "http://localhost:9093/api/v2/alerts"
+EXEC_POD: Final[list[str]] = ["kubectl", "exec", "-n", "monitoring", "vmalertmanager-vm-0", "--"]
+STALE_BACKUP_SECONDS: Final[int] = 30 * 60
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str
+    summary: str
+    details: list[str]
+
+    @property
+    def failed(self) -> bool:
+        return self.status == "fail"
+
+
+def run(command: list[str], input_text: str | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, input=input_text, check=False, capture_output=True, text=True)
+
+
+def kubectl_json(args: list[str]) -> Any:
+    result = run(["kubectl", *args, "-o", "json"])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"kubectl {' '.join(args)} failed")
+    return json.loads(result.stdout)
+
+
+def remote_get(url: str) -> Any:
+    result = run([*EXEC_POD, "wget", "-qO-", url])
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or f"request failed: {url}")
+    return json.loads(result.stdout)
+
+
+def parse_ready(value: str) -> tuple[int, int]:
+    ready, total = value.split("/", 1)
+    return int(ready), int(total)
+
+
+def check_nodes() -> CheckResult:
+    nodes = kubectl_json(["get", "nodes"])
+    bad = []
+    for node in nodes["items"]:
+        ready = next(
+            (condition for condition in node["status"]["conditions"] if condition["type"] == "Ready"),
+            None,
+        )
+        if ready is None or ready.get("status") != "True":
+            bad.append(node["metadata"]["name"])
+    status = "pass" if not bad else "fail"
+    return CheckResult(
+        "nodes",
+        status,
+        "all nodes Ready" if not bad else f"{len(bad)} nodes not Ready",
+        bad,
+    )
+
+
+def check_kube_vip() -> CheckResult:
+    pods = kubectl_json(["get", "pods", "-n", "kube-system", "-l", "app.kubernetes.io/name=kube-vip"])
+    bad = []
+    for pod in pods["items"]:
+        containers = pod["status"].get("containerStatuses", [])
+        if pod["status"].get("phase") != "Running" or any(not container.get("ready") for container in containers):
+            bad.append(pod["metadata"]["name"])
+    status = "pass" if not bad and pods["items"] else "fail"
+    summary = f"{len(pods['items'])} kube-vip pods ready" if status == "pass" else "kube-vip pod readiness failed"
+    return CheckResult("kube-vip", status, summary, bad)
+
+
+def check_cilium() -> CheckResult:
+    result = run(["kubectl", "exec", "-n", "kube-system", "ds/cilium", "--", "cilium-dbg", "status", "--brief"])
+    output = "\n".join(part for part in [result.stdout.strip(), result.stderr.strip()] if part)
+    return CheckResult(
+        "cilium",
+        "pass" if result.returncode == 0 and output.strip() == "OK" else "fail",
+        "Cilium status OK" if result.returncode == 0 and output.strip() == "OK" else "Cilium status check failed",
+        [output] if output else [],
+    )
+
+
+def check_not_ready_pods() -> CheckResult:
+    pods = kubectl_json(["get", "pods", "-A"])
+    bad = []
+    ignored_phases = {"Succeeded"}
+    for pod in pods["items"]:
+        phase = pod["status"].get("phase", "")
+        if phase in ignored_phases:
+            continue
+        statuses = pod["status"].get("containerStatuses", [])
+        waiting_reasons = [
+            status.get("state", {}).get("waiting", {}).get("reason")
+            for status in statuses
+            if status.get("state", {}).get("waiting", {}).get("reason")
+        ]
+        ready_count = sum(1 for status in statuses if status.get("ready"))
+        total = len(statuses)
+        if phase != "Running" or waiting_reasons or (total and ready_count != total):
+            name = f"{pod['metadata']['namespace']}/{pod['metadata']['name']}"
+            reason = ",".join(waiting_reasons) or phase or f"{ready_count}/{total} ready"
+            bad.append(f"{name}: {reason}")
+    status = "pass" if not bad else "fail"
+    return CheckResult(
+        "pods",
+        status,
+        "all active pods ready" if not bad else f"{len(bad)} active pods not ready",
+        bad[:30],
+    )
+
+
+def check_deployments() -> CheckResult:
+    deployments = kubectl_json(["get", "deploy", "-A"])
+    bad = []
+    for deploy in deployments["items"]:
+        spec = deploy.get("spec", {})
+        status = deploy.get("status", {})
+        desired = spec.get("replicas", 1)
+        ready = status.get("readyReplicas", 0)
+        available = status.get("availableReplicas", 0)
+        if ready != desired or available != desired:
+            bad.append(f"{deploy['metadata']['namespace']}/{deploy['metadata']['name']}: {ready}/{desired} ready")
+    return CheckResult(
+        "deployments",
+        "pass" if not bad else "fail",
+        "all deployments available" if not bad else f"{len(bad)} deployments unavailable",
+        bad,
+    )
+
+
+def cnpg_clusters() -> CheckResult:
+    clusters = kubectl_json(["get", "clusters.postgresql.cnpg.io", "-A"])
+    bad = []
+    for cluster in clusters["items"]:
+        status = cluster.get("status", {})
+        instances = int(status.get("instances", cluster.get("spec", {}).get("instances", 0)) or 0)
+        ready = int(status.get("readyInstances", 0) or 0)
+        phase = status.get("phase", "")
+        name = f"{cluster['metadata']['namespace']}/{cluster['metadata']['name']}"
+        if phase != "Cluster in healthy state" or ready != instances:
+            bad.append(f"{name}: {phase}, ready {ready}/{instances}")
+    return CheckResult(
+        "cnpg-clusters",
+        "pass" if not bad else "fail",
+        "all CNPG clusters healthy" if not bad else f"{len(bad)} CNPG clusters unhealthy",
+        bad,
+    )
+
+
+def cnpg_backups() -> CheckResult:
+    backups = kubectl_json(["get", "backups.postgresql.cnpg.io", "-A"])["items"]
+    clusters = kubectl_json(["get", "clusters.postgresql.cnpg.io", "-A"])["items"]
+    by_cluster: dict[str, list[dict[str, Any]]] = {}
+    for backup in backups:
+        key = f"{backup['metadata']['namespace']}/{backup['spec']['cluster']['name']}"
+        by_cluster.setdefault(key, []).append(backup)
+
+    bad: list[str] = []
+    details: list[str] = []
+    for cluster in clusters:
+        namespace = cluster["metadata"]["namespace"]
+        name = cluster["metadata"]["name"]
+        key = f"{namespace}/{name}"
+        cluster_backups = sorted(
+            by_cluster.get(key, []),
+            key=lambda item: item.get("status", {}).get("startedAt") or item["metadata"]["creationTimestamp"],
+        )
+        latest = cluster_backups[-1] if cluster_backups else None
+        latest_success = next(
+            (backup for backup in reversed(cluster_backups) if backup.get("status", {}).get("phase") == "completed"),
+            None,
+        )
+        latest_phase = latest.get("status", {}).get("phase", "unknown") if latest else "missing"
+        latest_success_time = latest_success.get("status", {}).get("stoppedAt", "-") if latest_success else "-"
+        details.append(f"{key}: latest={latest_phase}, last_success={latest_success_time}")
+
+        if latest is None:
+            bad.append(f"{key}: no Backup resources found")
+        elif latest_phase == "failed":
+            error = latest.get("status", {}).get("error", "unknown error")
+            bad.append(f"{key}: latest backup failed: {error}")
+        elif latest_phase == "started":
+            started_at = latest.get("status", {}).get("startedAt") or latest["metadata"]["creationTimestamp"]
+            if age_seconds(started_at) > STALE_BACKUP_SECONDS:
+                bad.append(f"{key}: latest backup still started since {started_at}")
+        if latest_success is None:
+            bad.append(f"{key}: no successful backup found")
+
+        archiver = archive_status_from_cluster(namespace, name)
+        if archiver.failed:
+            bad.extend(archiver.details)
+        details.extend(archiver.details)
+
+    return CheckResult(
+        "cnpg-backups",
+        "pass" if not bad else "fail",
+        "all CNPG backups and WAL archiving healthy" if not bad else f"{len(bad)} CNPG backup/WAL issues",
+        bad or details,
+    )
+
+
+def archive_status_from_cluster(namespace: str, name: str) -> CheckResult:
+    result = run(["kubectl", "cnpg", "status", "-n", namespace, name])
+    if result.returncode != 0:
+        return CheckResult("cnpg-wal", "fail", "cnpg status failed", [f"{namespace}/{name}: {result.stderr.strip()}"])
+    waiting = None
+    failing = False
+    for line in result.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Working WAL archiving:"):
+            failing = "Failing" in stripped
+        if stripped.startswith("WALs waiting to be archived:"):
+            waiting = stripped.rsplit(":", 1)[-1].strip()
+    details = []
+    if failing:
+        details.append(f"{namespace}/{name}: WAL archiving failing")
+    if waiting and waiting != "0":
+        details.append(f"{namespace}/{name}: {waiting} WALs waiting")
+    return CheckResult("cnpg-wal", "fail" if details else "pass", "WAL archiving checked", details)
+
+
+def age_seconds(timestamp: str) -> float:
+    parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    return (datetime.now(UTC) - parsed).total_seconds()
+
+
+def grafana_alerts() -> CheckResult:
+    query = urllib.parse.quote(ALERT_QUERY)
+    payload = remote_get(PROMETHEUS_QUERY_URL.format(query=query))
+    alerts = payload.get("data", {}).get("result", [])
+    details = []
+    for alert in alerts:
+        metric = alert.get("metric", {})
+        resource = alert_resource(metric)
+        namespace = metric.get("namespace", "-")
+        details.append(f"{metric.get('alertname', 'unknown')}: {namespace}/{resource}")
+    return CheckResult(
+        "grafana-alerts",
+        "pass" if not details else "fail",
+        "no firing non-Watchdog alerts" if not details else f"{len(details)} firing non-Watchdog alerts",
+        details,
+    )
+
+
+def alertmanager_summary() -> CheckResult:
+    alerts = remote_get(ALERTMANAGER_URL)
+    active = [
+        alert
+        for alert in alerts
+        if alert.get("status", {}).get("state") == "active"
+        and alert.get("labels", {}).get("alertname") != "Watchdog"
+    ]
+    details = []
+    for alert in active:
+        labels = alert.get("labels", {})
+        resource = alert_resource(labels)
+        details.append(f"{labels.get('alertname', 'unknown')}: {labels.get('namespace', '-')}/{resource}")
+    return CheckResult(
+        "alertmanager",
+        "pass" if not active else "fail",
+        "no active non-Watchdog Alertmanager alerts" if not active else f"{len(active)} active non-Watchdog alerts",
+        details,
+    )
+
+
+def alert_resource(labels: dict[str, Any]) -> str:
+    return (
+        labels.get("deployment")
+        or labels.get("statefulset")
+        or labels.get("daemonset")
+        or labels.get("job_name")
+        or labels.get("pod")
+        or labels.get("service")
+        or "-"
+    )
+
+
+def run_edge_smoke() -> CheckResult:
+    result = run(["task", "kubernetes:edge-smoke"])
+    output = "\n".join(part for part in [result.stdout.strip(), result.stderr.strip()] if part)
+    return CheckResult(
+        "edge-smoke",
+        "pass" if result.returncode == 0 else "fail",
+        "edge smoke passed" if result.returncode == 0 else "edge smoke failed",
+        output.splitlines()[-20:],
+    )
+
+
+def run_log_noise(period: str, top: str) -> CheckResult:
+    result = run(["task", "kubernetes:log-noise", f"PERIOD={period}", f"TOP={top}"])
+    output = "\n".join(part for part in [result.stdout.strip(), result.stderr.strip()] if part)
+    return CheckResult(
+        "log-noise",
+        "pass" if result.returncode == 0 else "fail",
+        "log-noise query completed" if result.returncode == 0 else "log-noise query failed",
+        output.splitlines()[-30:],
+    )
+
+
+def notify(results: list[CheckResult]) -> None:
+    failures = [result for result in results if result.failed]
+    if not failures:
+        return
+    title = "Cluster health: action needed"
+    message = "; ".join(f"{result.name}: {result.summary}" for result in failures)
+    run([os.path.join("scripts", "notify"), "--status", "failure", "--title", title, "--message", message])
+
+
+def print_text(results: list[CheckResult]) -> None:
+    print(f"Collected at {datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    print()
+    for result in results:
+        marker = "PASS" if result.status == "pass" else "FAIL"
+        print(f"[{marker}] {result.name}: {result.summary}")
+        for detail in result.details:
+            print(f"  - {detail}")
+        print()
+
+
+def selected_checks(args: argparse.Namespace) -> list[CheckResult]:
+    if args.command == "cnpg-health":
+        return [cnpg_clusters()]
+    if args.command == "cnpg-backups":
+        return [cnpg_backups()]
+    if args.command == "grafana-alerts":
+        return [grafana_alerts(), alertmanager_summary()]
+    if args.command == "morning-check":
+        results = [
+            check_nodes(),
+            check_kube_vip(),
+            check_cilium(),
+            check_not_ready_pods(),
+            check_deployments(),
+            cnpg_clusters(),
+            cnpg_backups(),
+            grafana_alerts(),
+            alertmanager_summary(),
+            run_edge_smoke(),
+        ]
+        if args.log_noise:
+            results.append(run_log_noise(args.period, args.top))
+        return results
+    return [
+        check_nodes(),
+        check_kube_vip(),
+        check_cilium(),
+        check_not_ready_pods(),
+        check_deployments(),
+        cnpg_clusters(),
+        grafana_alerts(),
+    ]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["health", "cnpg-health", "cnpg-backups", "grafana-alerts", "morning-check"])
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+    parser.add_argument("--notify", action="store_true", help="Send phone notification when failures are found")
+    parser.add_argument("--log-noise", action="store_true", help="Include log-noise in morning-check")
+    parser.add_argument("--period", default="1h", help="Log-noise period when --log-noise is used")
+    parser.add_argument("--top", default="20", help="Log-noise top count when --log-noise is used")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        results = selected_checks(args)
+    except RuntimeError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
+    else:
+        print_text(results)
+
+    if args.notify:
+        notify(results)
+
+    return 1 if any(result.failed for result in results) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/flux-local-build.sh
+++ b/scripts/flux-local-build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TARGET_PATH="${1:-./kubernetes}"
+API_VERSIONS="policy/v1/PodDisruptionBudget,monitoring.coreos.com/v1,monitoring.coreos.com/v1/ServiceMonitor,monitoring.coreos.com/v1/PodMonitor,monitoring.coreos.com/v1/PrometheusRule"
+
+flux_local() {
+  bash "${SCRIPT_DIR}/flux-local-container.sh" "$@"
+}
+
+if [[ -f "${TARGET_PATH}/ks.yaml" ]]; then
+  kustomization_name="$(basename "${TARGET_PATH}")"
+  target_absolute_path="$(realpath "${TARGET_PATH}")"
+
+  flux_local build kustomization "${kustomization_name}" --path ./kubernetes
+
+  while IFS= read -r helmrelease; do
+    flux_local build helmrelease "${helmrelease}" \
+      --path ./kubernetes \
+      --api-versions "${API_VERSIONS}"
+  done < <(
+    while IFS= read -r -d '' helmrelease_file; do
+      yq -r 'select(.kind == "HelmRelease") | .metadata.name' "${helmrelease_file}"
+    done < <(find "${target_absolute_path}" -type f \( -iname 'helmrelease.yaml' -o -iname 'helmrelease.yml' \) -print0)
+  )
+
+  exit 0
+fi
+
+flux_local build all \
+  --enable-helm \
+  --api-versions "${API_VERSIONS}" \
+  "${TARGET_PATH}"

--- a/scripts/flux-local-container.sh
+++ b/scripts/flux-local-container.sh
@@ -8,6 +8,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IMAGE="ghcr.io/allenporter/flux-local:v8.2.0"
+
+docker_args=(
+  --rm
+  -e PYTHONUNBUFFERED=1
+  -e HOME=/tmp
+  -e XDG_CACHE_HOME=/tmp/.cache
+  -e XDG_CONFIG_HOME=/tmp/.config
+  -v "${REPO_ROOT}:/workspace"
+  -w /workspace
+)
+
+git_dir="$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-dir 2>/dev/null || true)"
+git_common_dir="$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+
+if [[ -n "${git_common_dir}" && "${git_common_dir}" != "${REPO_ROOT}/.git" ]]; then
+  docker_args+=(-v "${git_common_dir}:${git_common_dir}:ro")
+fi
+
+if [[ -n "${git_dir}" && "${git_dir}" != "${REPO_ROOT}/.git" && "${git_dir}" != "${git_common_dir}" ]]; then
+  docker_args+=(-v "${git_dir}:${git_dir}:ro")
+fi
 
 # Run flux-local with all arguments passed through
-docker compose -f "${REPO_ROOT}/docker-compose.flux-local.yml" run --rm flux-local "$@"
+docker run "${docker_args[@]}" "${IMAGE}" "$@"

--- a/scripts/unifi/read-status.py
+++ b/scripts/unifi/read-status.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Read-only UniFi diagnostics for mesh/backhaul investigations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Final
+
+
+DEFAULT_CONTROLLER: Final[str] = "https://192.168.1.254"
+DEFAULT_SITE: Final[str] = "default"
+DEFAULT_SECRET_NAMESPACE: Final[str] = "network"
+DEFAULT_SECRET_NAME: Final[str] = "external-dns-unifi-secret"
+DEFAULT_SECRET_KEY: Final[str] = "api-key"
+
+DEFAULT_DEVICES: Final[tuple[str, ...]] = (
+    "U6-LR",
+    "U6-Mesh",
+    "U6 Pro",
+    "USW-Lite-8-PoE",
+)
+
+DEFAULT_WATCH_IPS: Final[tuple[str, ...]] = (
+    "U6-LR=192.168.1.155",
+    "U6-Mesh=192.168.1.109",
+    "USW-Lite-8-PoE=192.168.1.38",
+    "Garage=192.168.1.168",
+)
+
+DEFAULT_CLIENT_MACS: Final[tuple[str, ...]] = (
+    "70:a7:41:5f:13:d9",
+)
+
+
+@dataclass(frozen=True)
+class PingResult:
+    name: str
+    ip: str
+    ok: bool
+    detail: str
+
+
+class UnifiError(RuntimeError):
+    """Raised when UniFi data cannot be collected."""
+
+
+def parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def parse_watch_ips(value: str) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for item in parse_csv(value):
+        if "=" in item:
+            name, ip = item.split("=", 1)
+        elif ":" in item:
+            name, ip = item.split(":", 1)
+        else:
+            name = item
+            ip = item
+        entries.append((name.strip(), ip.strip()))
+    return entries
+
+
+def timestamp(value: Any) -> str:
+    if not isinstance(value, int | float) or value <= 0:
+        return "-"
+    return datetime.fromtimestamp(value, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def value_or_dash(value: Any) -> str:
+    if value is None or value == "":
+        return "-"
+    return str(value)
+
+
+def state_label(value: Any) -> str:
+    labels = {
+        0: "offline",
+        1: "online",
+        11: "adopting/pending",
+    }
+    return labels.get(value, value_or_dash(value))
+
+
+def run_kubectl_secret(namespace: str, name: str, key: str) -> str:
+    jsonpath = f"{{.data.{key}}}"
+    command = [
+        "kubectl",
+        "get",
+        "secret",
+        "-n",
+        namespace,
+        name,
+        "-o",
+        f"jsonpath={jsonpath}",
+    ]
+    result = subprocess.run(command, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise UnifiError(result.stderr.strip() or "kubectl secret read failed")
+
+    decode = subprocess.run(
+        ["base64", "-d"],
+        input=result.stdout,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if decode.returncode != 0:
+        raise UnifiError(decode.stderr.strip() or "base64 decode failed")
+    return decode.stdout.strip()
+
+
+class UnifiClient:
+    def __init__(self, controller: str, site: str, api_key: str) -> None:
+        self.controller = controller.rstrip("/")
+        self.site = site
+        self.api_key = api_key
+        self.context = ssl._create_unverified_context()
+
+    def get(self, path: str) -> dict[str, Any]:
+        url = f"{self.controller}{path}"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "X-API-KEY": self.api_key,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, context=self.context, timeout=20) as response:
+                body = response.read().decode("utf-8")
+        except urllib.error.URLError as exc:
+            raise UnifiError(f"UniFi request failed for {url}: {exc}") from exc
+        return json.loads(body)
+
+    def devices(self) -> list[dict[str, Any]]:
+        payload = self.get(f"/proxy/network/api/s/{self.site}/stat/device")
+        return list(payload.get("data", []))
+
+    def clients(self) -> list[dict[str, Any]]:
+        payload = self.get(f"/proxy/network/api/s/{self.site}/stat/sta")
+        return list(payload.get("data", []))
+
+
+def ping_targets(targets: list[tuple[str, str]]) -> list[PingResult]:
+    results: list[PingResult] = []
+    wait_arg = "1000" if platform.system() == "Darwin" else "1"
+    for name, ip in targets:
+        command = ["ping", "-c", "1", "-W", wait_arg, ip]
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+        detail = "reachable" if result.returncode == 0 else summarize_ping_failure(result)
+        results.append(PingResult(name=name, ip=ip, ok=result.returncode == 0, detail=detail))
+    return results
+
+
+def summarize_ping_failure(result: subprocess.CompletedProcess[str]) -> str:
+    output = "\n".join(part for part in (result.stdout.strip(), result.stderr.strip()) if part)
+    if "No route to host" in output:
+        return "no route to host"
+    if "100.0% packet loss" in output or "100% packet loss" in output:
+        return "timeout"
+    return output.splitlines()[-1] if output else f"ping exited {result.returncode}"
+
+
+def find_named_devices(devices: list[dict[str, Any]], names: list[str]) -> list[dict[str, Any]]:
+    by_name = {str(device.get("name", "")): device for device in devices}
+    return [by_name[name] for name in names if name in by_name]
+
+
+def find_clients(
+    clients: list[dict[str, Any]],
+    watch_ips: list[tuple[str, str]],
+    macs: list[str],
+) -> list[dict[str, Any]]:
+    ip_set = {ip for _, ip in watch_ips}
+    mac_set = {mac.lower() for mac in macs}
+    matches: list[dict[str, Any]] = []
+    for client in clients:
+        client_ip = str(client.get("ip", ""))
+        client_mac = str(client.get("mac", "")).lower()
+        if client_ip in ip_set or client_mac in mac_set:
+            matches.append(client)
+    return matches
+
+
+def print_table(headers: list[str], rows: list[list[Any]]) -> None:
+    text_rows = [[value_or_dash(value) for value in row] for row in rows]
+    widths = [
+        max(len(header), *(len(row[index]) for row in text_rows)) if text_rows else len(header)
+        for index, header in enumerate(headers)
+    ]
+    print("  ".join(header.ljust(widths[index]) for index, header in enumerate(headers)))
+    print("  ".join("-" * width for width in widths))
+    for row in text_rows:
+        print("  ".join(row[index].ljust(widths[index]) for index in range(len(headers))))
+
+
+def print_device_summary(devices: list[dict[str, Any]]) -> None:
+    print("Devices")
+    print_table(
+        ["name", "state", "ip", "model", "version", "last_seen", "disconnected_at"],
+        [
+            [
+                device.get("name"),
+                state_label(device.get("state")),
+                device.get("ip"),
+                device.get("model"),
+                device.get("version"),
+                timestamp(device.get("last_seen")),
+                timestamp(device.get("disconnected_at")),
+            ]
+            for device in devices
+        ],
+    )
+    print()
+
+
+def print_radio_summary(devices: list[dict[str, Any]]) -> None:
+    rows: list[list[Any]] = []
+    for device in devices:
+        for radio in device.get("radio_table", []) or []:
+            rows.append(
+                [
+                    device.get("name"),
+                    radio.get("radio"),
+                    radio.get("name"),
+                    radio.get("channel"),
+                    radio.get("ht"),
+                    radio.get("tx_power"),
+                    radio.get("tx_power_mode"),
+                    radio.get("vwire_enabled"),
+                ]
+            )
+    print("AP radios")
+    print_table(["device", "band", "radio", "channel", "width", "tx_power", "tx_mode", "mesh"], rows)
+    print()
+
+
+def print_wireless_uplinks(devices: list[dict[str, Any]]) -> None:
+    rows: list[list[Any]] = []
+    for device in devices:
+        uplink = device.get("uplink") or {}
+        if uplink.get("type") == "wireless":
+            rows.append(
+                [
+                    device.get("name"),
+                    uplink.get("uplink_device_name") or uplink.get("uplink_mac"),
+                    uplink.get("radio"),
+                    uplink.get("channel"),
+                    uplink.get("signal"),
+                    uplink.get("rssi"),
+                    uplink.get("tx_rate"),
+                    uplink.get("rx_rate"),
+                    uplink.get("is_mesh_v3"),
+                ]
+            )
+    print("Active wireless uplinks")
+    print_table(["device", "parent", "band", "channel", "signal", "rssi", "tx_rate", "rx_rate", "mesh_v3"], rows)
+    print()
+
+
+def print_peer_observations(devices: list[dict[str, Any]]) -> None:
+    rows: list[list[Any]] = []
+    for device in devices:
+        for peer in device.get("uplink_table", []) or []:
+            rows.append(
+                [
+                    device.get("name"),
+                    peer.get("mac"),
+                    peer.get("radio"),
+                    peer.get("channel"),
+                    peer.get("signal"),
+                    peer.get("rssi"),
+                    peer.get("noise"),
+                ]
+            )
+    print("Wireless peer observations")
+    print_table(["observer", "peer_mac", "band", "channel", "signal", "rssi", "noise"], rows)
+    print()
+
+
+def print_switch_ports(devices: list[dict[str, Any]]) -> None:
+    rows: list[list[Any]] = []
+    for device in devices:
+        for port in device.get("port_table", []) or []:
+            if port.get("port_idx") not in (1, 4):
+                continue
+            rows.append(
+                [
+                    device.get("name"),
+                    port.get("port_idx"),
+                    port.get("name"),
+                    port.get("up"),
+                    port.get("speed"),
+                    port.get("poe_power"),
+                    port.get("poe_voltage"),
+                    port.get("rx_errors"),
+                    port.get("tx_errors"),
+                    port.get("rx_dropped"),
+                    port.get("tx_dropped"),
+                    port.get("link_down_count"),
+                ]
+            )
+    if not rows:
+        return
+    print("Switch ports of interest")
+    print_table(
+        [
+            "switch",
+            "port",
+            "name",
+            "up",
+            "speed",
+            "poe_w",
+            "poe_v",
+            "rx_err",
+            "tx_err",
+            "rx_drop",
+            "tx_drop",
+            "link_down",
+        ],
+        rows,
+    )
+    print()
+
+
+def print_client_summary(clients: list[dict[str, Any]]) -> None:
+    if not clients:
+        return
+    print("Clients of interest")
+    print_table(
+        ["name", "hostname", "ip", "mac", "ap_mac", "sw_mac", "uptime", "last_seen"],
+        [
+            [
+                client.get("name"),
+                client.get("hostname"),
+                client.get("ip"),
+                client.get("mac"),
+                client.get("ap_mac"),
+                client.get("sw_mac"),
+                client.get("uptime"),
+                timestamp(client.get("last_seen")),
+            ]
+            for client in clients
+        ],
+    )
+    print()
+
+
+def print_ping_summary(results: list[PingResult]) -> None:
+    print("Reachability")
+    print_table(
+        ["name", "ip", "status", "detail"],
+        [[result.name, result.ip, "ok" if result.ok else "fail", result.detail] for result in results],
+    )
+    print()
+
+
+def build_payload(
+    selected_devices: list[dict[str, Any]],
+    selected_clients: list[dict[str, Any]],
+    pings: list[PingResult],
+) -> dict[str, Any]:
+    return {
+        "collected_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "devices": selected_devices,
+        "clients": selected_clients,
+        "reachability": [result.__dict__ for result in pings],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--controller", default=DEFAULT_CONTROLLER)
+    parser.add_argument("--site", default=DEFAULT_SITE)
+    parser.add_argument("--secret-namespace", default=DEFAULT_SECRET_NAMESPACE)
+    parser.add_argument("--secret-name", default=DEFAULT_SECRET_NAME)
+    parser.add_argument("--secret-key", default=DEFAULT_SECRET_KEY)
+    parser.add_argument("--devices", default=",".join(DEFAULT_DEVICES))
+    parser.add_argument("--watch-ips", default=",".join(DEFAULT_WATCH_IPS))
+    parser.add_argument("--client-macs", default=",".join(DEFAULT_CLIENT_MACS))
+    parser.add_argument("--json", action="store_true", help="Print raw selected data as JSON")
+    parser.add_argument("--no-ping", action="store_true", help="Skip local ICMP reachability checks")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    device_names = parse_csv(args.devices)
+    watch_ips = parse_watch_ips(args.watch_ips)
+    client_macs = parse_csv(args.client_macs.lower())
+
+    try:
+        api_key = run_kubectl_secret(args.secret_namespace, args.secret_name, args.secret_key)
+        client = UnifiClient(args.controller, args.site, api_key)
+        devices = client.devices()
+        clients = client.clients()
+    except UnifiError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        return 1
+
+    selected_devices = find_named_devices(devices, device_names)
+    selected_clients = find_clients(clients, watch_ips, client_macs)
+    pings = [] if args.no_ping else ping_targets(watch_ips)
+
+    if args.json:
+        print(json.dumps(build_payload(selected_devices, selected_clients, pings), indent=2, sort_keys=True))
+        return 0
+
+    print(f"Collected at {datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}")
+    print()
+    print_device_summary(selected_devices)
+    print_radio_summary(selected_devices)
+    print_wireless_uplinks(selected_devices)
+    print_peer_observations(selected_devices)
+    print_switch_ports(selected_devices)
+    print_client_summary(selected_clients)
+    if pings:
+        print_ping_summary(pings)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- explicitly map the Grafana OnCall plugin token from 1Password instead of extracting the whole item
- explicitly map the Alertmanager integration URL into the Alertmanager ExternalSecret template
- document the mapped fields and mark the Alertmanager URL as sensitive

## Verification
- task flux:local-build path=./kubernetes/apps/monitoring/grafana
- task flux:local-build path=./kubernetes/apps/monitoring/victoria-metrics
- task kubernetes:kubeconform