### PR TITLE
docs: clarify OnCall alert fanout

### DIFF
--- a/docs/GRAFANA-ONCALL-SETUP.md
+++ b/docs/GRAFANA-ONCALL-SETUP.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Grafana Cloud OnCall is the primary destination for actionable Alertmanager alerts. Pushover remains in the same Alertmanager receivers during rollout so alerts still produce the existing mobile signal while OnCall paging is verified.
+Grafana Cloud OnCall is configured as a second destination for actionable Alertmanager alerts. The existing Pushover receivers stay in place, and each receiver now fans out to both Grafana OnCall and Pushover.
 
 The local Grafana instance is managed through GitOps. Do not treat manual Grafana UI changes as authoritative; update the manifests and 1Password items instead.
 
@@ -53,7 +53,7 @@ In Grafana, verify:
 
 In Alertmanager, verify:
 
-- Receivers `pushover` and `pushover-critical` include an OnCall webhook.
+- Receivers `pushover` and `pushover-critical` include both an OnCall webhook and a Pushover config.
 - `Watchdog` still routes to Gatus heartbeat.
 - `InfoInhibitor` still routes to `null`.
 - Warning/info alerts still respect the DND mute intervals.

--- a/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
@@ -80,6 +80,7 @@ spec:
                       credentials: "{{ .GATUS_WATCHDOG_TOKEN }}"
             - name: "null"
             - name: pushover
+              # Fan out warning/info alerts to Grafana OnCall and Pushover.
               webhook_configs:
                 - send_resolved: true
                   max_alerts: 100
@@ -116,6 +117,7 @@ spec:
                   url_title: View in Alertmanager
                   user_key: "{{ .PUSHOVER_USER_KEY }}"
             - name: pushover-critical
+              # Fan out critical alerts to Grafana OnCall and high-priority Pushover.
               webhook_configs:
                 - send_resolved: true
                   max_alerts: 100


### PR DESCRIPTION
## Summary
- document Grafana OnCall as a second Alertmanager destination alongside Pushover
- add receiver comments showing warning/info and critical alerts fan out to both destinations

## Verification
- task flux:local-build path=./kubernetes/apps/monitoring/victoria-metrics
- task kubernetes:kubeconform