### PR TITLE
fix: restore Penpot WAL archiving

### DIFF
--- a/kubernetes/apps/home/penpot-db/app/cluster.yaml
+++ b/kubernetes/apps/home/penpot-db/app/cluster.yaml
@@ -37,7 +37,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: penpot-rustfs-store
-        serverName: penpot
+        serverName: penpot-pg18
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- move Penpot CNPG's Barman server name to a fresh PG18 namespace
- avoid collision with existing RustFS archive contents under the old penpot server path

## Verification
- task k8s:kubeconform
- kubectl cnpg status -n home penpot reported Working WAL archiving: OK and 0 WALs waiting
- on-demand backup penpot-manual-202605181605 completed