### PR TITLE
feat(postgres): prep zitadel and home assistant pg18 mirrors

### DIFF
--- a/.taskfiles/Postgres/Taskfile.yaml
+++ b/.taskfiles/Postgres/Taskfile.yaml
@@ -133,6 +133,11 @@ tasks:
     cmds:
       - "{{.SCRIPT}} subscription"
 
+  subscription-reset:
+    desc: "Delete/recreate the CNPG Subscription CR against green"
+    cmds:
+      - "{{.SCRIPT}} subscription-reset"
+
   monitor:
     desc: "Print pub/sub status + replication lag (one-shot)"
     cmds:

--- a/.taskfiles/Postgres/profiles/home-assistant.env
+++ b/.taskfiles/Postgres/profiles/home-assistant.env
@@ -1,0 +1,32 @@
+NAMESPACE=home-automation
+APP_DEPLOYMENTS=home-assistant
+APP_WORKLOADS=statefulset/home-assistant
+HELMRELEASE=home-assistant
+
+BLUE_CLUSTER=home-assistant
+GREEN_CLUSTER=home-assistant-green
+BLUE_DATABASE=app
+GREEN_DATABASE=app
+BLUE_USER=app
+GREEN_USER=app
+
+BLUE_APP_SECRET=home-assistant-app
+GREEN_APP_SECRET=home-assistant-green-app
+REQUIRED_APP_SECRET_KEYS="host user password dbname uri"
+
+PUBLICATION_NAME=home-assistant-green-pub
+SUBSCRIPTION_NAME=home-assistant-green-sub
+PUBLICATION_PG_NAME=home_assistant_green_pub
+SUBSCRIPTION_PG_NAME=home_assistant_green_sub
+
+STATE_DIR=.migration-state/home-assistant
+MIGRATION_MANIFEST_DIR=${REPO_ROOT}/kubernetes/apps/home-automation/home-assistant-db/migration
+HELMRELEASE_PATH=${REPO_ROOT}/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+
+CUTOVER_TARGET_TYPE=helm-value
+HELM_VALUE_PATH='.spec.values.controllers.home-assistant.containers.app.env[] | select(.name == "HASS_POSTGRES_URL").valueFrom.secretKeyRef.name'
+BLUE_HELM_VALUE=home-assistant-app
+GREEN_HELM_VALUE=home-assistant-green-app
+POSTCHECK_ENV_VAR=
+HEALTH_URL=https://home-assistant.damacus.io
+PROM_POD_REGEX=home-assistant.*

--- a/.taskfiles/Postgres/profiles/zitadel.env
+++ b/.taskfiles/Postgres/profiles/zitadel.env
@@ -1,0 +1,37 @@
+NAMESPACE=authentication
+APP_DEPLOYMENTS="zitadel zitadel-login"
+APP_WORKLOADS="deployment/zitadel deployment/zitadel-login"
+HELMRELEASE=zitadel
+
+BLUE_CLUSTER=zitadel
+GREEN_CLUSTER=zitadel-green
+BLUE_DATABASE=zitadel
+GREEN_DATABASE=zitadel
+BLUE_USER=zitadel
+GREEN_USER=zitadel
+
+BLUE_APP_SECRET=zitadel-db
+GREEN_APP_SECRET=zitadel-db
+REQUIRED_APP_SECRET_KEYS="username password"
+REPLICA_IDENTITY_FULL_TABLES="logstore.execution logstore.access"
+SCHEMA_REWRITE_UNLOGGED_TABLES=true
+
+PUBLICATION_NAME=zitadel-green-pub
+SUBSCRIPTION_NAME=zitadel-green-sub
+PUBLICATION_PG_NAME=zitadel_green_pub
+SUBSCRIPTION_PG_NAME=zitadel_green_sub
+
+STATE_DIR=.migration-state/zitadel
+MIGRATION_MANIFEST_DIR=${REPO_ROOT}/kubernetes/apps/authentication/zitadel-db/migration
+HELMRELEASE_PATH=${REPO_ROOT}/kubernetes/apps/authentication/zitadel/app/helmrelease.yaml
+
+CUTOVER_TARGET_TYPE=secret-key
+CUTOVER_FILE_PATH=${REPO_ROOT}/kubernetes/apps/authentication/zitadel/app/externalsecret.yaml
+YAML_VALUE_PATH='select(.metadata.name == "zitadel-credentials").spec.target.template.data.POSTGRES_HOST'
+CUTOVER_SECRET_NAME=zitadel-credentials
+CUTOVER_SECRET_KEY=POSTGRES_HOST
+BLUE_HELM_VALUE=zitadel-rw.authentication.svc.cluster.local
+GREEN_HELM_VALUE=zitadel-green-rw.authentication.svc.cluster.local
+POSTCHECK_ENV_VAR=ZITADEL_DATABASE_POSTGRES_HOST
+HEALTH_URL=https://zitadel.damacus.io/debug/ready
+PROM_POD_REGEX=zitadel.*

--- a/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
@@ -1,0 +1,71 @@
+---
+# Green CNPG cluster for the zitadel PG16 -> PG18 blue/green migration.
+# Applied imperatively during migration; not included in the Flux app kustomization.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: zitadel-green
+  namespace: authentication
+spec:
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql
+    major: 18
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+  enablePDB: true
+
+  bootstrap:
+    initdb:
+      database: zitadel
+      owner: zitadel
+      secret:
+        name: zitadel-db
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: zitadel-rustfs-store
+        serverName: zitadel-green
+
+  monitoring:
+    enablePodMonitor: true
+
+  storage:
+    size: 10Gi
+    storageClass: openebs-hostpath
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: zitadel-db-superuser
+
+  externalClusters:
+    - name: zitadel
+      connectionParameters:
+        host: zitadel-rw.authentication.svc.cluster.local
+        user: postgres
+        dbname: zitadel
+        port: "5432"
+        sslmode: prefer
+      password:
+        name: zitadel-db-superuser
+        key: password
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: 256MB
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 2000m
+      memory: 1Gi

--- a/kubernetes/apps/authentication/zitadel-db/migration/publication.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/migration/publication.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/publication_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Publication
+metadata:
+  name: zitadel-green-pub
+  namespace: authentication
+spec:
+  cluster:
+    name: zitadel
+  dbname: zitadel
+  name: zitadel_green_pub
+  publicationReclaimPolicy: delete
+  target:
+    allTables: true

--- a/kubernetes/apps/authentication/zitadel-db/migration/subscription.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/migration/subscription.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/subscription_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Subscription
+metadata:
+  name: zitadel-green-sub
+  namespace: authentication
+spec:
+  cluster:
+    name: zitadel-green
+  dbname: zitadel
+  name: zitadel_green_sub
+  publicationName: zitadel_green_pub
+  externalClusterName: zitadel
+  subscriptionReclaimPolicy: delete

--- a/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
@@ -1,0 +1,69 @@
+---
+# Green CNPG cluster for the home-assistant PG16 -> PG18 blue/green migration.
+# Applied imperatively during migration; not included in the Flux app kustomization.
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: home-assistant-green
+  namespace: home-automation
+spec:
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql
+    major: 18
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+  enablePDB: true
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: home-assistant-rustfs-store
+        serverName: home-assistant-green
+
+  monitoring:
+    enablePodMonitor: true
+
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+
+  enableSuperuserAccess: true
+
+  externalClusters:
+    - name: home-assistant
+      connectionParameters:
+        host: home-assistant-rw.home-automation.svc.cluster.local
+        user: postgres
+        dbname: app
+        port: "5432"
+        sslmode: prefer
+      password:
+        name: cloudnative-pg
+        key: password
+
+  postgresql:
+    parameters:
+      max_connections: "400"
+      shared_buffers: 256MB
+      effective_io_concurrency: "200"
+      maintenance_work_mem: 256MB
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 400Mi
+    limits:
+      memory: 2Gi
+      cpu: 3000m

--- a/kubernetes/apps/home-automation/home-assistant-db/migration/publication.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/migration/publication.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/publication_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Publication
+metadata:
+  name: home-assistant-green-pub
+  namespace: home-automation
+spec:
+  cluster:
+    name: home-assistant
+  dbname: app
+  name: home_assistant_green_pub
+  publicationReclaimPolicy: delete
+  target:
+    allTables: true

--- a/kubernetes/apps/home-automation/home-assistant-db/migration/subscription.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/migration/subscription.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/subscription_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Subscription
+metadata:
+  name: home-assistant-green-sub
+  namespace: home-automation
+spec:
+  cluster:
+    name: home-assistant-green
+  dbname: app
+  name: home_assistant_green_sub
+  publicationName: home_assistant_green_pub
+  externalClusterName: home-assistant
+  subscriptionReclaimPolicy: delete

--- a/scripts/pg-bluegreen.sh
+++ b/scripts/pg-bluegreen.sh
@@ -60,10 +60,14 @@ fi
 : "${STATE_DIR:=.migration-state/n8n}"
 : "${MIGRATION_MANIFEST_DIR:=${REPO_ROOT}/kubernetes/apps/home-automation/n8n-db/migration}"
 : "${HELMRELEASE_PATH:=${REPO_ROOT}/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml}"
-: "${CUTOVER_TARGET_TYPE:=secret-anchor}" # secret-anchor | helm-value | none
+: "${CUTOVER_TARGET_TYPE:=secret-anchor}" # secret-anchor | helm-value | secret-key | none
 : "${HELM_VALUE_PATH:=}"
 : "${BLUE_HELM_VALUE:=}"
 : "${GREEN_HELM_VALUE:=}"
+: "${CUTOVER_FILE_PATH:=}"
+: "${YAML_VALUE_PATH:=}"
+: "${CUTOVER_SECRET_NAME:=}"
+: "${CUTOVER_SECRET_KEY:=}"
 : "${REQUIRED_APP_SECRET_KEYS:=host user password dbname}"
 : "${REPLICA_IDENTITY_FULL_TABLES:=}"
 if [[ ! ${POSTCHECK_ENV_VAR+x} ]]; then POSTCHECK_ENV_VAR=DB_POSTGRESDB_HOST; fi
@@ -76,6 +80,7 @@ if [[ ! ${REQUIRE_APP_CONNECTIONS+x} ]]; then REQUIRE_APP_CONNECTIONS=true; fi
 : "${HEALTH_URL:=https://n8n.ironstone.casa/healthz}"
 : "${CONFIRM_CONTEXT:=false}"
 : "${FORCE_SCHEMA:=false}"
+: "${SCHEMA_REWRITE_UNLOGGED_TABLES:=false}"
 : "${ACCEPT_DATA_LOSS:=false}"
 : "${GRAFANA_MCP_ENABLED:=false}"
 
@@ -182,6 +187,10 @@ helmrelease_anchor() {
     | head -n1 | sed -E 's/.*&dbSecret[[:space:]]+([^[:space:]]+).*/\1/'
 }
 
+first_yaml_value() {
+  sed '/^[[:space:]]*$/d' | head -n1
+}
+
 repo_cutover_target() {
   case "${CUTOVER_TARGET_TYPE}" in
     secret-anchor)
@@ -189,7 +198,12 @@ repo_cutover_target() {
       ;;
     helm-value)
       [[ -n "${HELM_VALUE_PATH}" ]] || die "HELM_VALUE_PATH is required for CUTOVER_TARGET_TYPE=helm-value"
-      yq -r "${HELM_VALUE_PATH} // \"\"" "${HELMRELEASE_PATH}"
+      yq -rN "${HELM_VALUE_PATH}" "${HELMRELEASE_PATH}" | first_yaml_value
+      ;;
+    secret-key)
+      [[ -n "${CUTOVER_FILE_PATH}" ]] || die "CUTOVER_FILE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
+      [[ -n "${YAML_VALUE_PATH}" ]] || die "YAML_VALUE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
+      yq -rN "${YAML_VALUE_PATH}" "${CUTOVER_FILE_PATH}" | first_yaml_value
       ;;
     none)
       echo ""
@@ -209,7 +223,13 @@ live_cutover_target() {
     helm-value)
       [[ -n "${HELM_VALUE_PATH}" ]] || die "HELM_VALUE_PATH is required for CUTOVER_TARGET_TYPE=helm-value"
       kctl get helmrelease "${HELMRELEASE}" -o yaml 2>/dev/null \
-        | yq -r "${HELM_VALUE_PATH} // \"\""
+        | yq -rN "${HELM_VALUE_PATH}" - | first_yaml_value
+      ;;
+    secret-key)
+      [[ -n "${CUTOVER_SECRET_NAME}" ]] || die "CUTOVER_SECRET_NAME is required for CUTOVER_TARGET_TYPE=secret-key"
+      [[ -n "${CUTOVER_SECRET_KEY}" ]] || die "CUTOVER_SECRET_KEY is required for CUTOVER_TARGET_TYPE=secret-key"
+      kctl get secret "${CUTOVER_SECRET_NAME}" -o jsonpath="{.data.${CUTOVER_SECRET_KEY}}" 2>/dev/null \
+        | base64 -d
       ;;
     none)
       echo ""
@@ -224,6 +244,7 @@ blue_cutover_target() {
   case "${CUTOVER_TARGET_TYPE}" in
     secret-anchor) echo "${BLUE_APP_SECRET}" ;;
     helm-value)   echo "${BLUE_HELM_VALUE}" ;;
+    secret-key)   echo "${BLUE_HELM_VALUE}" ;;
     none)         echo "" ;;
   esac
 }
@@ -232,6 +253,7 @@ green_cutover_target() {
   case "${CUTOVER_TARGET_TYPE}" in
     secret-anchor) echo "${GREEN_APP_SECRET}" ;;
     helm-value)   echo "${GREEN_HELM_VALUE}" ;;
+    secret-key)   echo "${GREEN_HELM_VALUE}" ;;
     none)         echo "" ;;
   esac
 }
@@ -245,6 +267,11 @@ set_repo_cutover_target() {
     helm-value)
       [[ -n "${HELM_VALUE_PATH}" ]] || die "HELM_VALUE_PATH is required for CUTOVER_TARGET_TYPE=helm-value"
       yq -i "${HELM_VALUE_PATH} = \"${target}\"" "${HELMRELEASE_PATH}"
+      ;;
+    secret-key)
+      [[ -n "${CUTOVER_FILE_PATH}" ]] || die "CUTOVER_FILE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
+      [[ -n "${YAML_VALUE_PATH}" ]] || die "YAML_VALUE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
+      yq -i "${YAML_VALUE_PATH} = \"${target}\"" "${CUTOVER_FILE_PATH}"
       ;;
     none)
       ;;
@@ -637,6 +664,10 @@ cmd_copy_schema() {
   log "dumping schema from blue (${blue_pod})"
   kctl exec -c postgres "${blue_pod}" -- \
     pg_dump --schema-only --no-owner --no-acl --dbname "${BLUE_DATABASE}" >"${schema_file}"
+  if [[ "${SCHEMA_REWRITE_UNLOGGED_TABLES}" == "true" ]]; then
+    log "rewriting CREATE UNLOGGED TABLE to CREATE TABLE for PG18 schema compatibility"
+    sed -i.bak 's/^CREATE UNLOGGED TABLE /CREATE TABLE /' "${schema_file}"
+  fi
   log "schema written to ${schema_file} ($(wc -l <"${schema_file}") lines)"
 
   log "restoring schema into green (${green_pod})"
@@ -721,6 +752,12 @@ cmd_subscription() {
   else
     ok "subscription streaming. received_lsn=${lsn}"
   fi
+}
+
+cmd_subscription_reset() {
+  require_tools
+  kctl delete --ignore-not-found subscription "${SUBSCRIPTION_NAME}"
+  cmd_subscription
 }
 
 # ----------------------------------------------------------------------------
@@ -1312,6 +1349,7 @@ usage: pg-bluegreen.sh <subcommand>
   copy-schema                pg_dump --schema-only from blue -> green
   publication                apply CNPG Publication CR
   subscription               apply CNPG Subscription CR
+  subscription-reset         delete/recreate CNPG Subscription CR
   monitor                    print pub/sub + replication status
   ready                      exit 0 if green is caught up
   cutover                    perform write-stop window + hand off to operator
@@ -1336,6 +1374,7 @@ main() {
     copy-schema)       cmd_copy_schema "$@" ;;
     publication)       cmd_publication "$@" ;;
     subscription)      cmd_subscription "$@" ;;
+    subscription-reset) cmd_subscription_reset "$@" ;;
     monitor)           cmd_monitor "$@" ;;
     ready)             cmd_ready "$@" ;;
     cutover)           cmd_cutover "$@" ;;


### PR DESCRIPTION
## Summary
- add reusable profiles and migration manifests for Zitadel and Home Assistant PG18 mirrors
- add secret-key cutover target support for app credentials managed by ExternalSecret
- add subscription-reset and schema rewrite support for PG18 preflight/mirroring edge cases

## Validation
- bash -n scripts/pg-bluegreen.sh
- task postgres:preflight PG_PROFILE=zitadel CONFIRM_CONTEXT=true
- task postgres:all-but-cutover PG_PROFILE=zitadel CONFIRM_CONTEXT=true
- task postgres:ready PG_PROFILE=zitadel CONFIRM_CONTEXT=true
- task postgres:preflight PG_PROFILE=home-assistant CONFIRM_CONTEXT=true
- task postgres:all-but-cutover PG_PROFILE=home-assistant CONFIRM_CONTEXT=true
- task postgres:subscription-reset PG_PROFILE=home-assistant CONFIRM_CONTEXT=true

## Notes
- Zitadel is READY on green mirroring and still points at blue.
- Home Assistant is mirroring and still points at blue; three relations are still in data-copy state: event_data, migration_changes, recorder_runs.
