### PR TITLE
feat(postgres): prep zitadel and home assistant pg18 mirrors

### DIFF
--- a/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
@@ -29,7 +29,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: zitadel-rustfs-store
-        serverName: zitadel-green
+        serverName: zitadel-green-20260519b
 
   monitoring:
     enablePodMonitor: true

--- a/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
@@ -27,7 +27,7 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: home-assistant-rustfs-store
-        serverName: home-assistant-green
+        serverName: home-assistant-green-20260519b
 
   monitoring:
     enablePodMonitor: true

--- a/scripts/pg-bluegreen.sh
+++ b/scripts/pg-bluegreen.sh
@@ -214,6 +214,23 @@ repo_cutover_target() {
   esac
 }
 
+repo_cutover_file() {
+  case "${CUTOVER_TARGET_TYPE}" in
+    secret-anchor|helm-value)
+      echo "${HELMRELEASE_PATH}"
+      ;;
+    secret-key)
+      echo "${CUTOVER_FILE_PATH}"
+      ;;
+    none)
+      echo ""
+      ;;
+    *)
+      die "unknown CUTOVER_TARGET_TYPE='${CUTOVER_TARGET_TYPE}'"
+      ;;
+  esac
+}
+
 live_cutover_target() {
   case "${CUTOVER_TARGET_TYPE}" in
     secret-anchor)
@@ -304,11 +321,12 @@ restore_app_replicas() {
 
 resume_cutover_after_handoff() {
   local state_file=$1
-  local target expected
+  local target expected cutover_file
   target=$(repo_cutover_target)
   expected=$(green_cutover_target)
+  cutover_file=$(repo_cutover_file)
   [[ "${target}" == "${expected}" ]] \
-    || die "cutover target in ${HELMRELEASE_PATH} is '${target}', expected '${expected}'. App may still be scaled to 0; complete the cutover edit or rollback."
+    || die "cutover target in ${cutover_file:-repo} is '${target}', expected '${expected}'. App may still be scaled to 0; complete the cutover edit or rollback."
 
   log "restoring app replica counts"
   restore_app_replicas "${state_file}"
@@ -1021,28 +1039,31 @@ cmd_cutover() {
   ok "row counts match"
   save_cutover_stage "${state_file}" "awaiting-handoff"
 
-  if [[ "${CUTOVER_TARGET_TYPE}" == "helm-value" ]]; then
-    log "updating repo cutover target in ${HELMRELEASE_PATH}"
+  if [[ "${CUTOVER_TARGET_TYPE}" == "helm-value" || "${CUTOVER_TARGET_TYPE}" == "secret-key" ]]; then
+    log "updating repo cutover target in $(repo_cutover_file)"
     set_repo_cutover_target "$(green_cutover_target)"
   fi
+
+  local cutover_file
+  cutover_file=$(repo_cutover_file)
 
   cat <<EOF
 
 ${BOLD}===================================================================${RESET}
-${BOLD}MANUAL STEP REQUIRED — commit the HelmRelease cutover edit${RESET}
+${BOLD}MANUAL STEP REQUIRED — commit the cutover edit${RESET}
 ${BOLD}===================================================================${RESET}
 
-In ${HELMRELEASE_PATH}, verify the configured cutover target:
+In ${cutover_file}, verify the configured cutover target:
 
   - ${CUTOVER_TARGET_TYPE}: $(blue_cutover_target)
   + ${CUTOVER_TARGET_TYPE}: $(green_cutover_target)
 
 Then:
 
-  git add ${HELMRELEASE_PATH}
+  git add ${cutover_file}
   git commit -m "feat(${HELMRELEASE}): cut over to ${GREEN_CLUSTER} (PG18)"
   git push
-  flux reconcile helmrelease ${HELMRELEASE} -n ${NAMESPACE}
+  flux reconcile kustomization ${HELMRELEASE} -n flux-system
 
 Once the cutover edit is reconciled, re-run:
 
@@ -1075,7 +1096,7 @@ EOF
   target=$(repo_cutover_target)
   expected_green=$(green_cutover_target)
   [[ "${target}" == "${expected_green}" ]] \
-    || die "cutover target in ${HELMRELEASE_PATH} is '${target}', expected '${expected_green}'. App is still scaled to 0; complete the cutover edit or rollback."
+    || die "cutover target in ${cutover_file:-repo} is '${target}', expected '${expected_green}'. App is still scaled to 0; complete the cutover edit or rollback."
 
   resume_cutover_after_handoff "${state_file}"
 }


### PR DESCRIPTION
## Summary
- add generic CNPG blue/green profiles for Zitadel and Home Assistant
- repair secret-key cutover handoff support in the Taskfile runbook
- re-key green Barman archive server names to clean PG18 paths

## Validation
- bash -n scripts/pg-bluegreen.sh
- task postgres:create-green PG_PROFILE=zitadel CONFIRM_CONTEXT=true
- task postgres:create-green PG_PROFILE=home-assistant CONFIRM_CONTEXT=true
- task postgres:ready PG_PROFILE=zitadel CONFIRM_CONTEXT=true
- task postgres:ready PG_PROFILE=home-assistant CONFIRM_CONTEXT=true