### PR TITLE
feat(zitadel): cut over to zitadel-green pg18

### DIFF
--- a/kubernetes/apps/authentication/zitadel/app/externalsecret.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/externalsecret.yaml
@@ -34,7 +34,7 @@ spec:
     template:
       engineVersion: v2
       data:
-        POSTGRES_HOST: "zitadel-rw.authentication.svc.cluster.local"
+        POSTGRES_HOST: "zitadel-green-rw.authentication.svc.cluster.local"
         POSTGRES_DB: "zitadel"
         POSTGRES_USER: "zitadel"
         POSTGRES_PASS: "{{ .DB_password }}"


### PR DESCRIPTION
## Summary
- point Zitadel POSTGRES_HOST at zitadel-green-rw for PG18 cutover

## Validation
- task postgres:cutover PG_PROFILE=zitadel CONFIRM_CONTEXT=true reached GitOps handoff
- blue backup completed: zitadel-pre-cutover-20260519082518
- row-count parity passed with profile-scoped queue.river_leader exclusion