### PR TITLE
feat(home-assistant): cut over to home-assistant-green pg18

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
@@ -47,7 +47,7 @@ spec:
               - name: HASS_POSTGRES_URL
                 valueFrom:
                   secretKeyRef:
-                    name: home-assistant-app
+                    name: home-assistant-green-app
                     key: uri
             envFrom:
               - secretRef:

--- a/scripts/pg-bluegreen.sh
+++ b/scripts/pg-bluegreen.sh
@@ -285,12 +285,12 @@ set_repo_cutover_target() {
       ;;
     helm-value)
       [[ -n "${HELM_VALUE_PATH}" ]] || die "HELM_VALUE_PATH is required for CUTOVER_TARGET_TYPE=helm-value"
-      yq -i "${HELM_VALUE_PATH} = \"${target}\"" "${HELMRELEASE_PATH}"
+      yq -i "(${HELM_VALUE_PATH}) = \"${target}\"" "${HELMRELEASE_PATH}"
       ;;
     secret-key)
       [[ -n "${CUTOVER_FILE_PATH}" ]] || die "CUTOVER_FILE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
       [[ -n "${YAML_VALUE_PATH}" ]] || die "YAML_VALUE_PATH is required for CUTOVER_TARGET_TYPE=secret-key"
-      yq -i "${YAML_VALUE_PATH} = \"${target}\"" "${CUTOVER_FILE_PATH}"
+      yq -i "(${YAML_VALUE_PATH}) = \"${target}\"" "${CUTOVER_FILE_PATH}"
       ;;
     none)
       ;;


### PR DESCRIPTION
## Summary
- point Home Assistant HASS_POSTGRES_URL at the PG18 green app secret
- fix the generic yq cutover edit for filtered value paths

## Validation
- task postgres:cutover PG_PROFILE=home-assistant CONFIRM_CONTEXT=true reached GitOps handoff
- blue backup completed: home-assistant-pre-cutover-20260519084300
- row-count parity passed