### PR TITLE
feat(postgres): remove cutover blue databases

### DIFF
--- a/kubernetes/apps/authentication/zitadel-db/app/cluster.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/app/cluster.yaml
@@ -3,46 +3,43 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: &name zitadel
+  name: &name zitadel-green
   namespace: authentication
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   storage:
     size: 10Gi
     storageClass: openebs-hostpath
-
   monitoring:
     enablePodMonitor: true
-
   bootstrap:
     initdb:
-      database: *name
-      owner: *name
+      database: zitadel
+      owner: zitadel
       secret:
         name: zitadel-db
-
   enableSuperuserAccess: true
   superuserSecret:
     name: zitadel-db-superuser
-
   postgresql:
     parameters:
       max_connections: "100"
       shared_buffers: 256MB
-
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: zitadel-rustfs-store
-        serverName: zitadel
-
+        serverName: zitadel-green-20260519b
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/authentication/zitadel-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: zitadel-db
+  name: zitadel-green
   namespace: authentication
 spec:
   schedule: "0 4 * * *"
@@ -15,4 +15,4 @@ spec:
     parameters:
       objectStore: zitadel-rustfs-store
   cluster:
-    name: zitadel
+    name: zitadel-green

--- a/kubernetes/apps/dev/forgejo-db/app/cluster.yaml
+++ b/kubernetes/apps/dev/forgejo-db/app/cluster.yaml
@@ -3,50 +3,46 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: &name forgejo
+  name: &name forgejo-green
   namespace: dev
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   enablePDB: true
-
   bootstrap:
     initdb:
-      database: *name
-      owner: *name
+      database: forgejo
+      owner: forgejo
       secret:
         name: forgejo-db
-
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: forgejo-rustfs-store
-        serverName: forgejo
-
+        serverName: forgejo-green
   monitoring:
     enablePodMonitor: true
-
   storage:
     size: 10Gi
     storageClass: openebs-hostpath
-
   enableSuperuserAccess: true
   superuserSecret:
     name: cloudnative-pg
-
   postgresql:
     parameters:
       max_connections: "200"
       shared_buffers: 128MB
       effective_io_concurrency: "200"
       maintenance_work_mem: 128MB
-
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
   resources:
     requests:
       cpu: 50m

--- a/kubernetes/apps/dev/forgejo-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/dev/forgejo-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: forgejo
+  name: forgejo-green
   namespace: dev
 spec:
   schedule: "0 0 0 * * *"
@@ -14,4 +14,4 @@ spec:
     parameters:
       objectStore: forgejo-rustfs-store
   cluster:
-    name: forgejo
+    name: forgejo-green

--- a/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
@@ -3,43 +3,38 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: home-assistant
+  name: home-assistant-green
   namespace: home-automation
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   enablePDB: true
-
   monitoring:
     enablePodMonitor: true
-
   storage:
     size: 20Gi
     storageClass: openebs-hostpath
-
   enableSuperuserAccess: true
-  superuserSecret:
-    name: cloudnative-pg-secret
-
   postgresql:
     parameters:
       max_connections: "400"
       shared_buffers: 256MB
       effective_io_concurrency: "200"
       maintenance_work_mem: 256MB
-
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: home-assistant-rustfs-store
-        serverName: home-assistant
-
+        serverName: home-assistant-green-20260519b
   resources:
     requests:
       cpu: 50m
@@ -47,3 +42,7 @@ spec:
     limits:
       memory: 2Gi
       cpu: 3000m
+  bootstrap:
+    initdb:
+      database: app
+      owner: app

--- a/kubernetes/apps/home-automation/home-assistant-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: home-assistant-db
+  name: home-assistant-green
   namespace: home-automation
 spec:
   schedule: "0 0 0 * * *"
@@ -15,4 +15,4 @@ spec:
     parameters:
       objectStore: home-assistant-rustfs-store
   cluster:
-    name: home-assistant
+    name: home-assistant-green

--- a/kubernetes/apps/home-automation/n8n-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/n8n-db/app/cluster.yaml
@@ -3,38 +3,31 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: n8n
+  name: n8n-green
   namespace: home-automation
-  annotations:
-    cnpg.io/hibernation: "on"
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   enablePDB: true
-
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: n8n-rustfs-store
-        serverName: n8n
-
+        serverName: n8n-green
   monitoring:
     enablePodMonitor: true
-
   storage:
     size: 10Gi
     storageClass: openebs-hostpath
-
   enableSuperuserAccess: true
   superuserSecret:
     name: n8n-superuser
-
   postgresql:
     parameters:
       max_connections: "200"
@@ -45,7 +38,6 @@ spec:
       wal_level: logical
       max_replication_slots: "10"
       max_wal_senders: "10"
-
   resources:
     requests:
       cpu: 50m
@@ -53,3 +45,7 @@ spec:
     limits:
       memory: 1Gi
       cpu: 1000m
+  bootstrap:
+    initdb:
+      database: app
+      owner: app

--- a/kubernetes/apps/home-automation/n8n-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home-automation/n8n-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: n8n
+  name: n8n-green
   namespace: home-automation
 spec:
   schedule: "0 0 0 * * *"
@@ -14,4 +14,4 @@ spec:
     parameters:
       objectStore: n8n-rustfs-store
   cluster:
-    name: n8n
+    name: n8n-green

--- a/kubernetes/apps/home/immich-db/app/cluster.yaml
+++ b/kubernetes/apps/home/immich-db/app/cluster.yaml
@@ -3,47 +3,42 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: &name immich
+  name: &name immich-green
   namespace: home
-  annotations:
-    cnpg.io/hibernation: "on"
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   enablePDB: true
-
   storage:
     size: 10Gi
     storageClass: openebs-hostpath
-
   bootstrap:
     initdb:
-      database: *name
-      owner: *name
+      database: immich
+      owner: immich
       secret:
         name: immich-db
-
   enableSuperuserAccess: true
   superuserSecret:
     name: immich-db-superuser
-
   postgresql:
     parameters:
       max_connections: "100"
       shared_buffers: 256MB
-
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: immich-rustfs-store
-        serverName: immich
-
+        serverName: immich-green
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/home/immich-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home/immich-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: immich-db
+  name: immich-green
   namespace: home
 spec:
   schedule: "0 3 * * *"
@@ -15,4 +15,4 @@ spec:
     parameters:
       objectStore: immich-rustfs-store
   cluster:
-    name: immich
+    name: immich-green

--- a/kubernetes/apps/home/mealie-db/app/cluster.yaml
+++ b/kubernetes/apps/home/mealie-db/app/cluster.yaml
@@ -3,46 +3,43 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: &name mealie
+  name: &name mealie-green
   namespace: home
 spec:
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog
     name: postgresql
-    major: 16
+    major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
   storage:
     size: 5Gi
     storageClass: openebs-hostpath
-
   monitoring:
     enablePodMonitor: true
-
   bootstrap:
     initdb:
-      database: *name
-      owner: *name
+      database: mealie
+      owner: mealie
       secret:
         name: mealie-db
-
   enableSuperuserAccess: true
   superuserSecret:
     name: mealie-db-superuser
-
   postgresql:
     parameters:
       max_connections: "100"
       shared_buffers: 128MB
-
+      wal_level: logical
+      max_replication_slots: "10"
+      max_wal_senders: "10"
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: mealie-rustfs-store
-        serverName: mealie
-
+        serverName: mealie-green
   resources:
     requests:
       cpu: 100m

--- a/kubernetes/apps/home/mealie-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home/mealie-db/app/scheduledbackup.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: mealie-db
+  name: mealie-green
   namespace: home
 spec:
   schedule: "0 4 * * *"
@@ -15,4 +15,4 @@ spec:
     parameters:
       objectStore: mealie-rustfs-store
   cluster:
-    name: mealie
+    name: mealie-green

--- a/scripts/cluster-health.py
+++ b/scripts/cluster-health.py
@@ -21,6 +21,7 @@ PROMETHEUS_QUERY_URL: Final[str] = (
 ALERTMANAGER_URL: Final[str] = "http://localhost:9093/api/v2/alerts"
 EXEC_POD: Final[list[str]] = ["kubectl", "exec", "-n", "monitoring", "vmalertmanager-vm-0", "--"]
 STALE_BACKUP_SECONDS: Final[int] = 30 * 60
+HIBERNATION_ANNOTATION: Final[str] = "cnpg.io/hibernation"
 
 
 @dataclass
@@ -181,6 +182,9 @@ def cnpg_backups() -> CheckResult:
         namespace = cluster["metadata"]["namespace"]
         name = cluster["metadata"]["name"]
         key = f"{namespace}/{name}"
+        if cnpg_cluster_hibernated(cluster):
+            details.append(f"{key}: hibernated, backup/WAL check skipped")
+            continue
         cluster_backups = sorted(
             by_cluster.get(key, []),
             key=lambda item: item.get("status", {}).get("startedAt") or item["metadata"]["creationTimestamp"],
@@ -216,6 +220,18 @@ def cnpg_backups() -> CheckResult:
         "pass" if not bad else "fail",
         "all CNPG backups and WAL archiving healthy" if not bad else f"{len(bad)} CNPG backup/WAL issues",
         bad or details,
+    )
+
+
+def cnpg_cluster_hibernated(cluster: dict[str, Any]) -> bool:
+    annotations = cluster.get("metadata", {}).get("annotations", {})
+    if annotations.get(HIBERNATION_ANNOTATION) == "on":
+        return True
+
+    conditions = cluster.get("status", {}).get("conditions", [])
+    return any(
+        condition.get("type") == HIBERNATION_ANNOTATION and condition.get("status") == "True"
+        for condition in conditions
     )
 
 

--- a/tests/test_cluster_health.py
+++ b/tests/test_cluster_health.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+SCRIPT_PATH = pathlib.Path(__file__).resolve().parents[1] / "scripts" / "cluster-health.py"
+
+
+def load_cluster_health():
+    spec = importlib.util.spec_from_file_location("cluster_health", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["cluster_health"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CnpgBackupsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cluster_health = load_cluster_health()
+
+    def test_hibernated_clusters_are_skipped(self) -> None:
+        cluster = {
+            "metadata": {
+                "annotations": {"cnpg.io/hibernation": "on"},
+                "name": "immich",
+                "namespace": "home",
+            },
+            "status": {
+                "conditions": [
+                    {"type": "cnpg.io/hibernation", "status": "True"},
+                ],
+            },
+        }
+        backup = {
+            "metadata": {
+                "creationTimestamp": "2026-05-19T09:03:00Z",
+                "namespace": "home",
+            },
+            "spec": {"cluster": {"name": "immich"}},
+            "status": {
+                "error": "cannot backup a hibernated cluster",
+                "phase": "failed",
+            },
+        }
+
+        result = self.run_cnpg_backups([backup], [cluster])
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.summary, "all CNPG backups and WAL archiving healthy")
+        self.assertEqual(result.details, ["home/immich: hibernated, backup/WAL check skipped"])
+
+    def test_failed_backup_still_fails_for_active_cluster(self) -> None:
+        cluster = {
+            "metadata": {
+                "annotations": {},
+                "name": "app",
+                "namespace": "default",
+            },
+            "status": {},
+        }
+        backup = {
+            "metadata": {
+                "creationTimestamp": "2026-05-19T09:03:00Z",
+                "namespace": "default",
+            },
+            "spec": {"cluster": {"name": "app"}},
+            "status": {
+                "error": "backup failed",
+                "phase": "failed",
+            },
+        }
+
+        result = self.run_cnpg_backups([backup], [cluster])
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.details, ["default/app: latest backup failed: backup failed", "default/app: no successful backup found"])
+
+    def run_cnpg_backups(self, backups: list[dict], clusters: list[dict]):
+        def kubectl_json(args: list[str]):
+            if args == ["get", "backups.postgresql.cnpg.io", "-A"]:
+                return {"items": backups}
+            if args == ["get", "clusters.postgresql.cnpg.io", "-A"]:
+                return {"items": clusters}
+            raise AssertionError(f"unexpected kubectl args: {args}")
+
+        def archive_status_from_cluster(namespace: str, name: str):
+            return self.cluster_health.CheckResult("cnpg-wal", "pass", "WAL archiving checked", [])
+
+        self.cluster_health.kubectl_json = kubectl_json
+        self.cluster_health.archive_status_from_cluster = archive_status_from_cluster
+
+        return self.cluster_health.cnpg_backups()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip hibernated CNPG clusters in backup health checks
- promote cutover PG18 green clusters into the Flux-managed DB app paths
- retarget scheduled backups to the green clusters for n8n, immich, forgejo, mealie, home-assistant, and zitadel

## Validation
- python3 -m unittest tests.test_cluster_health
- python3 -m py_compile scripts/cluster-health.py tests/test_cluster_health.py
- task kubernetes:kubeconform
- task flux:local-test
- task kubernetes:cnpg-backups