### PR TITLE
fix: clean cluster alert remediation

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
@@ -21,7 +21,7 @@ spec:
             group_by: ["alertname", "job"]
             group_interval: 10m
             group_wait: 1m
-            receiver: pushover
+            receiver: oncall
             repeat_interval: 12h
             routes:
               - receiver: heartbeat
@@ -33,10 +33,10 @@ spec:
               - receiver: "null"
                 matchers:
                   - alertname=~"InfoInhibitor"
-              - receiver: pushover-critical
+              - receiver: oncall-critical
                 matchers:
                   - severity="critical"
-              - receiver: pushover
+              - receiver: oncall
                 mute_time_intervals:
                   - weekday-evenings
                   - weekends
@@ -79,84 +79,17 @@ spec:
                     authorization:
                       credentials: "{{ .GATUS_WATCHDOG_TOKEN }}"
             - name: "null"
-            - name: pushover
-              # Fan out warning/info alerts to Grafana OnCall and Pushover.
+            - name: oncall
               webhook_configs:
                 - send_resolved: true
                   max_alerts: 100
                   url: "{{ .GRAFANA_ONCALL_ALERTMANAGER_URL }}"
-              pushover_configs:
-                - html: true
-                  message: |-
-                    {{ "{{-" }} range .Alerts {{ "}}" }}
-                      {{ "{{-" }} if ne .Annotations.description "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.description {{ "}}" }}
-                      {{ "{{-" }} else if ne .Annotations.summary "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.summary {{ "}}" }}
-                      {{ "{{-" }} else if ne .Annotations.message "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.message {{ "}}" }}
-                      {{ "{{-" }} else {{ "}}" }}
-                        Alert description not available
-                      {{ "{{-" }} end {{ "}}" }}
-                      {{ "{{-" }} if gt (len .Labels.SortedPairs) 0 {{ "}}" }}
-                        <small>
-                        {{ "{{-" }} range .Labels.SortedPairs {{ "}}" }}
-                          <b>{{ "{{" }} .Name {{ "}}" }}:</b> {{ "{{" }} .Value {{ "}}" }}
-                        {{ "{{-" }} end {{ "}}" }}
-                        </small>
-                      {{ "{{-" }} end {{ "}}" }}
-                    {{ "{{-" }} end {{ "}}" }}
-                  priority: |-
-                    {{ "{{" }} if eq .Status "firing" {{ "}}" }}0{{ "{{" }} else {{ "}}" }}-1{{ "{{" }} end {{ "}}" }}
-                  send_resolved: true
-                  sound: gamelan
-                  title: >-
-                    [{{ "{{" }} .Status | toUpper {{ "}}" }}{{ "{{" }} if eq .Status "firing" {{ "}}" }}:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}{{ "{{" }} end {{ "}}" }}]
-                    {{ "{{" }} .CommonLabels.alertname {{ "}}" }}
-                  token: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
-                  url_title: View in Alertmanager
-                  user_key: "{{ .PUSHOVER_USER_KEY }}"
-            - name: pushover-critical
-              # Fan out critical alerts to Grafana OnCall and high-priority Pushover.
+            - name: oncall-critical
               webhook_configs:
                 - send_resolved: true
                   max_alerts: 100
                   url: "{{ .GRAFANA_ONCALL_ALERTMANAGER_URL }}"
-              pushover_configs:
-                - html: true
-                  message: |-
-                    🚨 CRITICAL ALERT 🚨
-                    {{ "{{-" }} range .Alerts {{ "}}" }}
-                      {{ "{{-" }} if ne .Annotations.description "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.description {{ "}}" }}
-                      {{ "{{-" }} else if ne .Annotations.summary "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.summary {{ "}}" }}
-                      {{ "{{-" }} else if ne .Annotations.message "" {{ "}}" }}
-                        {{ "{{" }} .Annotations.message {{ "}}" }}
-                      {{ "{{-" }} else {{ "}}" }}
-                        Alert description not available
-                      {{ "{{-" }} end {{ "}}" }}
-                      {{ "{{-" }} if gt (len .Labels.SortedPairs) 0 {{ "}}" }}
-                        <small>
-                        {{ "{{-" }} range .Labels.SortedPairs {{ "}}" }}
-                          <b>{{ "{{" }} .Name {{ "}}" }}:</b> {{ "{{" }} .Value {{ "}}" }}
-                        {{ "{{-" }} end {{ "}}" }}
-                        </small>
-                      {{ "{{-" }} end {{ "}}" }}
-                    {{ "{{-" }} end {{ "}}" }}
-                  priority: |-
-                    {{ "{{" }} if eq .Status "firing" {{ "}}" }}2{{ "{{" }} else {{ "}}" }}0{{ "{{" }} end {{ "}}" }}
-                  send_resolved: true
-                  sound: siren
-                  title: >-
-                    🔴 [{{ "{{" }} .Status | toUpper {{ "}}" }}{{ "{{" }} if eq .Status "firing" {{ "}}" }}:{{ "{{" }} .Alerts.Firing | len {{ "}}" }}{{ "{{" }} end {{ "}}" }}]
-                    {{ "{{" }} .CommonLabels.alertname {{ "}}" }}
-                  token: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
-                  url_title: View in Alertmanager
-                  user_key: "{{ .PUSHOVER_USER_KEY }}"
   dataFrom:
-    - extract:
-        key: pushover
     - extract:
         key: alertmanager
     - extract:

--- a/kubernetes/apps/storage/longhorn/app/PrometheusRule.yaml
+++ b/kubernetes/apps/storage/longhorn/app/PrometheusRule.yaml
@@ -47,7 +47,7 @@ spec:
               Longhorn volume {{$labels.volume}} on {{$labels.node}} is Fault for
               more than 2 minutes.
             summary: Longhorn volume {{$labels.volume}} is Fault
-          expr: longhorn_volume_robustness == 3
+          expr: longhorn_volume_robustness{state="faulted"} == 1
           for: 5m
           labels:
             issue: Longhorn volume {{$labels.volume}} is Fault.
@@ -59,7 +59,7 @@ spec:
               Longhorn volume {{$labels.volume}} on {{$labels.node}} is Degraded for
               more than 5 minutes.
             summary: Longhorn volume {{$labels.volume}} is Degraded
-          expr: longhorn_volume_robustness == 2
+          expr: longhorn_volume_robustness{state="degraded"} == 1
           for: 5m
           labels:
             issue: Longhorn volume {{$labels.volume}} is Degraded.
@@ -124,7 +124,7 @@ spec:
             severity: warning
 
         - alert: LonghornVolumeDegraded
-          expr: longhorn_volume_robustness == 1
+          expr: longhorn_volume_robustness{state="degraded"} == 1
           for: 2m
           labels:
             severity: warning


### PR DESCRIPTION
## Summary
- switch Immich database GitOps to manage immich-green and back it up
- route Alertmanager notifications through Grafana OnCall only
- correct Longhorn robustness alert expressions for state-labelled metrics

## Verification
- task k8s:kubeconform
- pre-commit hooks from git commit