### PR TITLE
harden(rustfs): pin mc image and tighten pod security for bucket-init Job

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -12,10 +12,20 @@ spec:
   template:
     spec:
       restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mc
-          image: minio/mc:latest
-          imagePullPolicy: IfNotPresent
+          image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: RUSTFS_ENDPOINT
               value: "http://rustfs.storage.svc.cluster.local:9000"


### PR DESCRIPTION
### Motivation
- The RustFS bucket initialization Job previously ran an unpinned mutable image and consumed admin/root-equivalent `rustfs-credentials`, creating a supply-chain exposure for backup/log credentials. 
- Running a mutable `minio/mc:latest` image with `IfNotPresent` risked executing attacker-controlled code that could exfiltrate or misuse the injected admin credentials. 
- The change aims to reduce credential exposure while preserving the existing bucket creation behavior. 

### Description
- Modified `kubernetes/apps/storage/rustfs/app/job-buckets.yaml` to replace the mutable `minio/mc:latest` image with a pinned release tag `minio/mc:RELEASE.2025-04-16T18-13-26Z` and set `imagePullPolicy: Always`. 
- Disabled service account token mounting for the Job by adding `automountServiceAccountToken: false` at the pod spec level. 
- Added pod-level `securityContext` with `runAsNonRoot: true` and `seccompProfile.type: RuntimeDefault` to reduce the attack surface. 
- Hardened the container with `securityContext` settings including `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and `capabilities.drop: ["ALL"]`, while keeping the original bucket initialization script and loop unchanged. 

### Testing
- Parsed the updated manifest with Python YAML loader using `yaml.safe_load(...)` to validate manifest syntax, which succeeded. 
- Attempts to validate remote image digests with `skopeo`, `crane`, and `regctl` were not possible in this environment because those tools are not installed or registry access returned `403`, and `task`-based checks could not be run because `task` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dbd48964832283d1a28428904e44)