### PR TITLE
fix(security): restrict redis ingress to n8n pods

### DIFF
--- a/kubernetes/apps/database/redis/app/kustomization.yaml
+++ b/kubernetes/apps/database/redis/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/database/redis/app/networkpolicy.yaml
+++ b/kubernetes/apps/database/redis/app/networkpolicy.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: redis-ingress
+  namespace: database
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: master
+      app.kubernetes.io/instance: redis
+      app.kubernetes.io/name: redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: home-automation
+            k8s:app.kubernetes.io/instance: n8n
+            k8s:app.kubernetes.io/name: n8n
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP


### PR DESCRIPTION
### Motivation
- Prevent unauthorized manipulation of n8n's Bull queue by limiting access to the unauthenticated Redis master used by n8n workers.

### Description
- Add `kubernetes/apps/database/redis/app/networkpolicy.yaml`, a `CiliumNetworkPolicy` that selects Redis master pods and allows ingress on TCP/6379 only from n8n pods in the `home-automation` namespace.
- Update `kubernetes/apps/database/redis/app/kustomization.yaml` to include the new `networkpolicy.yaml` so Flux will apply the policy.

### Testing
- Verified the working tree changes are limited to `kubernetes/apps/database/redis/app/networkpolicy.yaml` and `kubernetes/apps/database/redis/app/kustomization.yaml` and inspected the files with `git diff` and `nl -ba`, both showing the intended edits and contents.
- Confirmed the new policy is syntactically present and referenced by kustomization; no runtime unit tests were applicable and the change preserves existing n8n behavior while restricting Redis ingress.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dc773b3c8322a83720c07e0157d5)