### PR TITLE
fix: restrict redis ingress clients

### DIFF
--- a/kubernetes/apps/database/redis/app/kustomization.yaml
+++ b/kubernetes/apps/database/redis/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - networkpolicy.yaml

--- a/kubernetes/apps/database/redis/app/networkpolicy.yaml
+++ b/kubernetes/apps/database/redis/app/networkpolicy.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: redis-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/component: master
+      app.kubernetes.io/instance: redis
+      app.kubernetes.io/name: redis
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: home-automation
+            k8s:app.kubernetes.io/instance: n8n
+            k8s:app.kubernetes.io/name: n8n
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: home-automation
+            k8s:app.kubernetes.io/controller: paperless
+            k8s:app.kubernetes.io/instance: paperless
+            k8s:app.kubernetes.io/name: paperless
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: home
+            k8s:app.kubernetes.io/controller: backend
+            k8s:app.kubernetes.io/instance: penpot
+            k8s:app.kubernetes.io/name: penpot
+      toPorts:
+        - ports:
+            - port: "6379"
+              protocol: TCP


### PR DESCRIPTION
## Summary
- add a Redis CiliumNetworkPolicy that selects Redis master pods
- allow Redis ingress on TCP/6379 only from existing Redis clients: n8n, paperless, and penpot backend
- include the policy in the Redis kustomization

## Testing
- task k8s:kubeconform