### PR TITLE
fix(rustfs): replace mc bucket client

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -11,39 +11,47 @@ spec:
   ttlSecondsAfterFinished: 3600
   template:
     spec:
-      restartPolicy: OnFailure
       automountServiceAccountToken: false
+      restartPolicy: OnFailure
       securityContext:
         runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:
-        - name: mc
-          image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-          imagePullPolicy: Always
+        - name: rc
+          image: rustfs/rc:v0.1.16
+          imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
             capabilities:
-              drop: ["ALL"]
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
           env:
             - name: RUSTFS_ENDPOINT
               value: "http://rustfs.storage.svc.cluster.local:9000"
             - name: BUCKETS
               value: "cnpg-backups loki-data loki-chunks volsync-backups app-data backups cloudnative-pg longhorn"
+            - name: HOME
+              value: /tmp
           envFrom:
             - secretRef:
                 name: rustfs-credentials
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           command: ["/bin/sh", "-c"]
           args:
             - |
               set -eu
-              echo "Configuring mc alias and waiting for RustFS at $${RUSTFS_ENDPOINT:?}..."
+              echo "Configuring rc alias and waiting for RustFS at $${RUSTFS_ENDPOINT:?}..."
               i=1
               ready=false
               while [ "$i" -le 60 ]; do
-                if mc alias set rustfs "$${RUSTFS_ENDPOINT:?}" "$${RUSTFS_ACCESS_KEY:?}" "$${RUSTFS_SECRET_KEY:?}" >/dev/null 2>&1; then
-                  if mc ls rustfs >/dev/null 2>&1; then
+                if rc alias set rustfs "$${RUSTFS_ENDPOINT:?}" "$${RUSTFS_ACCESS_KEY:?}" "$${RUSTFS_SECRET_KEY:?}" >/dev/null 2>&1; then
+                  if rc bucket list rustfs/ >/dev/null 2>&1; then
                     echo "RustFS is reachable"
                     ready=true
                     break
@@ -60,5 +68,8 @@ spec:
 
               for b in ${BUCKETS}; do
                 echo "Creating bucket: $b"
-                mc mb --ignore-existing "rustfs/${b}"
+                rc bucket create --ignore-existing "rustfs/${b}"
               done
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- Replace the RustFS bucket bootstrap Job client image with rustfs/rc:v0.1.16.
- Switch bucket readiness and creation from mc commands to rc bucket commands.
- Preserve hardened non-root, read-only-rootfs execution with writable /tmp for rc config.

Follow-up to #3537.

## Verification

- task kubernetes:kubeconform
- kustomize build kubernetes/apps/storage/rustfs/app --load-restrictor=LoadRestrictionsNone
- docker run --rm --read-only --user 10001:10001 --tmpfs /tmp --entrypoint /bin/sh rustfs/rc:v0.1.16 -c 'HOME=/tmp rc alias set local http://127.0.0.1:9000 accesskey secretkey'