### PR TITLE
feat: add mondoo operator

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -134,6 +134,20 @@ tasks:
           sh: "test -f {{.KUBECONFORM_SCRIPT}}",
         }
 
+  mondoo-operator-assertions:
+    desc: Assert the Mondoo Operator GitOps manifests are wired safely
+    cmds:
+      - yq -e '.resources | contains(["mondoo.yaml"])' {{.KUBERNETES_DIR}}/flux/repositories/helm/kustomization.yaml
+      - yq -e '.metadata.name == "mondoo" and .spec.url == "https://mondoohq.github.io/mondoo-operator"' {{.KUBERNETES_DIR}}/flux/repositories/helm/mondoo.yaml
+      - yq -e '.resources | contains(["./namespace.yaml", "./mondoo-operator/ks.yaml"])' {{.KUBERNETES_DIR}}/apps/security/kustomization.yaml
+      - yq -e '.metadata.name == "mondoo-operator" and .metadata.namespace == "flux-system" and .spec.targetNamespace == "mondoo-operator" and .spec.path == "./kubernetes/apps/security/mondoo-operator/app"' {{.KUBERNETES_DIR}}/apps/security/mondoo-operator/ks.yaml
+      - yq -e '.spec.chart.spec.chart == "mondoo-operator" and .spec.chart.spec.version == "13.1.1" and .spec.chart.spec.sourceRef.name == "mondoo"' {{.KUBERNETES_DIR}}/apps/security/mondoo-operator/app/helmrelease.yaml
+      - yq -e '.spec.secretStoreRef.name == "onepassword-connect" and .spec.target.name == "mondoo-client" and (.spec.target.template.data.config | contains("MONDOO_CONFIG_JSON")) and .spec.dataFrom[0].extract.key == "mondoo"' {{.KUBERNETES_DIR}}/apps/security/mondoo-operator/app/externalsecret.yaml
+      - yq -e '[(.spec.mondooCredsSecretRef.name == "mondoo-client"), (.spec.kubernetesResources.enable == true), (.spec.nodes.enable == true), (.spec.nodes.style == "cronjob"), (.spec.containers.enable == false), ((.spec.kubernetesResources.resourceWatcher | type) == "!!null")] | all' {{.KUBERNETES_DIR}}/apps/security/mondoo-operator/app/auditconfig.yaml
+      - yq -e '.spec.filtering.namespaces.exclude | contains(["mondoo-operator", "kube-system", "flux-system"])' {{.KUBERNETES_DIR}}/apps/security/mondoo-operator/app/auditconfig.yaml
+    preconditions:
+      - { msg: "Missing yq", sh: "command -v yq >/dev/null" }
+
   object-storage-migrate:
     desc: Copy or sync objects between MinIO and RustFS with local rclone
     summary: |

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./mondoo-operator/ks.yaml

--- a/kubernetes/apps/security/mondoo-operator/app/auditconfig.yaml
+++ b/kubernetes/apps/security/mondoo-operator/app/auditconfig.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: k8s.mondoo.com/v1alpha2
+kind: MondooAuditConfig
+metadata:
+  name: mondoo-client
+  namespace: mondoo-operator
+spec:
+  mondooCredsSecretRef:
+    name: mondoo-client
+  kubernetesResources:
+    enable: true
+    schedule: "17 3 * * *"
+  nodes:
+    enable: true
+    style: cronjob
+    schedule: "47 3 * * *"
+  containers:
+    enable: false
+  filtering:
+    namespaces:
+      exclude:
+        - mondoo-operator
+        - kube-system
+        - flux-system
+        - external-secrets
+        - cert-manager
+        - system-upgrade

--- a/kubernetes/apps/security/mondoo-operator/app/externalsecret.yaml
+++ b/kubernetes/apps/security/mondoo-operator/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mondoo-client
+  namespace: mondoo-operator
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mondoo-client
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        config: "{{ .MONDOO_CONFIG_JSON }}"
+  dataFrom:
+    - extract:
+        key: mondoo

--- a/kubernetes/apps/security/mondoo-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/security/mondoo-operator/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mondoo-operator
+  namespace: mondoo-operator
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: mondoo-operator
+      version: 13.1.1
+      sourceRef:
+        kind: HelmRepository
+        name: mondoo
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    operator:
+      createConfig: true

--- a/kubernetes/apps/security/mondoo-operator/app/kustomization.yaml
+++ b/kubernetes/apps/security/mondoo-operator/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./auditconfig.yaml

--- a/kubernetes/apps/security/mondoo-operator/ks.yaml
+++ b/kubernetes/apps/security/mondoo-operator/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mondoo-operator
+  namespace: flux-system
+spec:
+  targetNamespace: mondoo-operator
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/security/mondoo-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/security/namespace.yaml
+++ b/kubernetes/apps/security/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mondoo-operator
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/flux/repositories/helm/kustomization.yaml
+++ b/kubernetes/flux/repositories/helm/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - kured.yaml
   - longhorn.yaml
   - metrics-server.yaml
+  - mondoo.yaml
   - onepassword-connect.yaml
   - openebs.yaml
   - prometheus-community.yaml

--- a/kubernetes/flux/repositories/helm/mondoo.yaml
+++ b/kubernetes/flux/repositories/helm/mondoo.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mondoo
+  namespace: flux-system
+spec:
+  interval: 12h
+  url: https://mondoohq.github.io/mondoo-operator


### PR DESCRIPTION
## Summary
- add the Mondoo Helm repository and Flux-managed operator app
- sync Mondoo service account JSON from 1Password into the mondoo-client secret
- enable scheduled Kubernetes resource and node scans while leaving image scanning and realtime watching off
- add a yq-based assertion task for the Mondoo operator manifests

## Verification
- task k8s:mondoo-operator-assertions
- task k8s:kubeconform
- task flux:local-test path=./kubernetes