### PR TITLE
fix: cut over Mealie RustFS backups

### DIFF
--- a/kubernetes/apps/home/mealie-db/app/objectstore.yaml
+++ b/kubernetes/apps/home/mealie-db/app/objectstore.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   retentionPolicy: 30d
   configuration:
-    destinationPath: s3://cnpg-backups/mealie
+    destinationPath: s3://cnpg-mealie/
     endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-mealie
         key: ACCESS_KEY_ID
       secretAccessKey:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-mealie
         key: SECRET_ACCESS_KEY
     data:
       compression: bzip2

--- a/tests/mondoo/rustfs-iam.mql.yaml
+++ b/tests/mondoo/rustfs-iam.mql.yaml
@@ -14,9 +14,9 @@ policies:
         email: security@ironstone.casa
     docs:
       desc: |
-        Validate the RustFS IAM canary rollout. Penpot CNPG is cut over to its
-        per-app bucket and credential while every other backup consumer keeps
-        using the old shared/root-backed resources for rollback.
+        Validate the RustFS IAM canary rollout. Penpot and Mealie CNPG are cut
+        over to their per-app buckets and credentials while every other backup
+        consumer keeps using the old shared/root-backed resources for rollback.
     groups:
       - title: CNPG Consumers Stay On Existing RustFS Resources
         filters: asset.platform != ""
@@ -61,12 +61,13 @@ policies:
               file("kubernetes/apps/home/immich-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials")
               file("kubernetes/apps/home/immich-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-immich")
               file("kubernetes/apps/home/immich-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-immich")
-          - uid: phase1-mealie-cnpg-keeps-current-consumer
-            title: Mealie CNPG keeps current bucket and stages per-app secret
+          - uid: phase2-mealie-cnpg-uses-canary-consumer
+            title: Mealie CNPG uses the per-app bucket and credential canary
             impact: 100
             mql: |
-              file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-backups/mealie")
-              file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials")
+              file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-mealie/")
+              file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-mealie")
+              file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials") == false
               file("kubernetes/apps/home/mealie-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-mealie")
               file("kubernetes/apps/home/mealie-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-mealie")
           - uid: phase1-med-tracker-cnpg-keeps-current-consumer


### PR DESCRIPTION
## Summary
- cut over Mealie CNPG backups to the per-app RustFS bucket and credential
- update the RustFS IAM Mondoo contract for the Penpot + Mealie hybrid canary state
- preserve old shared/root-backed resources for rollback and leave all other consumers unchanged

## Stability gate
- PR #3550 merged at 2026-05-19T21:12:58Z
- Penpot ObjectStore reconciled to s3://cnpg-penpot/ with rustfs-cnpg-penpot
- Penpot recorded a fresh successful backup at 2026-05-19T22:05:06Z after cutover
- live RustFS IAM policy passed

## Verification
- task k8s:rustfs-iam-policy
- task k8s:kubeconform
- task flux:local-test path=./kubernetes
- task k8s:rustfs-iam-live-policy
- git diff --check