### PR TITLE
fix: cut over more RustFS backups

### DIFF
--- a/kubernetes/apps/dev/forgejo-db/app/objectstore.yaml
+++ b/kubernetes/apps/dev/forgejo-db/app/objectstore.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   retentionPolicy: 30d
   configuration:
-    destinationPath: s3://cnpg-backups/forgejo
+    destinationPath: s3://cnpg-forgejo/
     endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-forgejo
         key: ACCESS_KEY_ID
       secretAccessKey:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-forgejo
         key: SECRET_ACCESS_KEY
     data:
       compression: bzip2

--- a/kubernetes/apps/home/med-tracker-db/app/objectstore.yaml
+++ b/kubernetes/apps/home/med-tracker-db/app/objectstore.yaml
@@ -8,14 +8,14 @@ metadata:
 spec:
   retentionPolicy: 30d
   configuration:
-    destinationPath: s3://cnpg-backups/med-tracker
+    destinationPath: s3://cnpg-med-tracker/
     endpointURL: http://rustfs.storage.svc.cluster.local:9000
     s3Credentials:
       accessKeyId:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-med-tracker
         key: ACCESS_KEY_ID
       secretAccessKey:
-        name: rustfs-cnpg-credentials
+        name: rustfs-cnpg-med-tracker
         key: SECRET_ACCESS_KEY
     data:
       compression: bzip2

--- a/tests/mondoo/rustfs-iam.mql.yaml
+++ b/tests/mondoo/rustfs-iam.mql.yaml
@@ -14,9 +14,10 @@ policies:
         email: security@ironstone.casa
     docs:
       desc: |
-        Validate the RustFS IAM canary rollout. Penpot and Mealie CNPG are cut
-        over to their per-app buckets and credentials while every other backup
-        consumer keeps using the old shared/root-backed resources for rollback.
+        Validate the RustFS IAM canary rollout. Penpot, Mealie, Forgejo, and Med
+        Tracker CNPG are cut over to their per-app buckets and credentials while
+        every other backup consumer keeps using the old shared/root-backed
+        resources for rollback.
     groups:
       - title: CNPG Consumers Stay On Existing RustFS Resources
         filters: asset.platform != ""
@@ -29,12 +30,13 @@ policies:
               file("kubernetes/apps/authentication/zitadel-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials")
               file("kubernetes/apps/authentication/zitadel-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-zitadel")
               file("kubernetes/apps/authentication/zitadel-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-zitadel")
-          - uid: phase1-forgejo-cnpg-keeps-current-consumer
-            title: Forgejo CNPG keeps current bucket and stages per-app secret
+          - uid: phase2-forgejo-cnpg-uses-canary-consumer
+            title: Forgejo CNPG uses the per-app bucket and credential canary
             impact: 100
             mql: |
-              file("kubernetes/apps/dev/forgejo-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-backups/forgejo")
-              file("kubernetes/apps/dev/forgejo-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials")
+              file("kubernetes/apps/dev/forgejo-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-forgejo/")
+              file("kubernetes/apps/dev/forgejo-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-forgejo")
+              file("kubernetes/apps/dev/forgejo-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials") == false
               file("kubernetes/apps/dev/forgejo-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-forgejo")
               file("kubernetes/apps/dev/forgejo-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-forgejo")
           - uid: phase1-home-assistant-cnpg-keeps-current-consumer
@@ -70,12 +72,13 @@ policies:
               file("kubernetes/apps/home/mealie-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials") == false
               file("kubernetes/apps/home/mealie-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-mealie")
               file("kubernetes/apps/home/mealie-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-mealie")
-          - uid: phase1-med-tracker-cnpg-keeps-current-consumer
-            title: Med Tracker CNPG keeps current bucket and stages per-app secret
+          - uid: phase2-med-tracker-cnpg-uses-canary-consumer
+            title: Med Tracker CNPG uses the per-app bucket and credential canary
             impact: 100
             mql: |
-              file("kubernetes/apps/home/med-tracker-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-backups/med-tracker")
-              file("kubernetes/apps/home/med-tracker-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials")
+              file("kubernetes/apps/home/med-tracker-db/app/objectstore.yaml").content.contains("destinationPath: s3://cnpg-med-tracker/")
+              file("kubernetes/apps/home/med-tracker-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-med-tracker")
+              file("kubernetes/apps/home/med-tracker-db/app/objectstore.yaml").content.contains("name: rustfs-cnpg-credentials") == false
               file("kubernetes/apps/home/med-tracker-db/app/externalsecret.yaml").content.contains("name: rustfs-cnpg-med-tracker")
               file("kubernetes/apps/home/med-tracker-db/app/externalsecret.yaml").content.contains("key: rustfs-cnpg-med-tracker")
           - uid: phase2-penpot-cnpg-uses-canary-consumer


### PR DESCRIPTION
## Summary
- cut over Forgejo CNPG backups to the per-app RustFS bucket and credential
- cut over Med Tracker CNPG backups to the per-app RustFS bucket and credential
- update the RustFS IAM Mondoo contract for the expanded hybrid state
- preserve old shared/root-backed resources, old bucket mirror references, and all non-selected consumers for the final migration audit

## Stability gate
- PR #3551 merged and Mealie reconciled to s3://cnpg-mealie/ with rustfs-cnpg-mealie
- Mealie recorded a fresh successful backup at 2026-05-20T06:04:05Z after cutover
- live RustFS IAM policy passed before this batch

## Verification
- task k8s:rustfs-iam-policy
- task k8s:kubeconform
- task flux:local-test path=./kubernetes
- task k8s:rustfs-iam-live-policy
- git diff --check