### PR TITLE
fix: add registry pull secrets

### DIFF
--- a/kubernetes/apps/authentication/zitadel-db/app/cluster.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name zitadel-green
   namespace: authentication
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/authentication/zitadel-db/migration/cluster-green.yaml
@@ -8,6 +8,8 @@ metadata:
   name: zitadel-green
   namespace: authentication
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/authentication/zitadel/app/helmrelease.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/helmrelease.yaml
@@ -28,6 +28,9 @@ spec:
   values:
     replicaCount: 1
 
+    imagePullSecrets:
+      - name: ghcr-credentials
+
     image:
       repository: ghcr.io/zitadel/zitadel
       tag: v4.15.0

--- a/kubernetes/apps/database/cloudnative-pg/app/plugin-barman-cloud.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/plugin-barman-cloud.yaml
@@ -912,6 +912,8 @@ spec:
       labels:
         app: barman-cloud
     spec:
+      imagePullSecrets:
+      - name: ghcr-credentials
       containers:
       - args:
         - operator

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -31,6 +31,10 @@ spec:
     remediation:
       retries: 3
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       dragonfly-operator:
         replicas: 1

--- a/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
+++ b/kubernetes/apps/database/dragonfly/cluster/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: dragonfly
 spec:
   image: ghcr.io/dragonflydb/dragonfly:v1.38.1@sha256:baf70ba7ad182a992b988497cfa31a488978c8fab7712079784c2401f447e402
+  imagePullSecrets:
+    - name: ghcr-credentials
   replicas: 1
   env:
     - name: MAX_MEMORY

--- a/kubernetes/apps/database/redis/app/helmrelease.yaml
+++ b/kubernetes/apps/database/redis/app/helmrelease.yaml
@@ -19,6 +19,10 @@ spec:
     remediation:
       retries: 3
   values:
+    global:
+      imagePullSecrets:
+        - dockerhub-credentials
+
     architecture: standalone
     resources:
       limits:

--- a/kubernetes/apps/default/unifi-release-announcer/app/HelmRelease.yaml
+++ b/kubernetes/apps/default/unifi-release-announcer/app/HelmRelease.yaml
@@ -25,6 +25,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       app:
         containers:

--- a/kubernetes/apps/dev/forgejo-db/app/cluster.yaml
+++ b/kubernetes/apps/dev/forgejo-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name forgejo-green
   namespace: dev
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/dev/forgejo-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/dev/forgejo-db/migration/cluster-green.yaml
@@ -8,6 +8,8 @@ metadata:
   name: forgejo-green
   namespace: dev
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/config/values.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/config/values.yaml
@@ -1,5 +1,9 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-3.6.0/charts/other/app-template/values.schema.json
+defaultPodOptions:
+  imagePullSecrets:
+    - name: dockerhub-credentials
+
 controllers:
   one-password:
     strategy: RollingUpdate

--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/dockerhub-externalsecret.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/dockerhub-externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name dockerhub-credentials
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "database,external-secrets,home,monitoring,network,openebs-system,reflector,storage,system-upgrade"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "database,external-secrets,home,monitoring,network,openebs-system,reflector,storage,system-upgrade"
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "https://index.docker.io/v1/": {
+                "username": "{{ .username }}",
+                "password": "{{ .password }}",
+                "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+              }
+            }
+          }
+  dataFrom:
+    - extract:
+        key: dockerhub

--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/ghcr-externalsecret.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/ghcr-externalsecret.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name ghcr-credentials
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        annotations:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "authentication,database,default,dev,flux-system,home,home-automation,kube-system,monitoring,network"
+          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "authentication,database,default,dev,flux-system,home,home-automation,kube-system,monitoring,network"
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "{{ .username }}",
+                "password": "{{ .password }}",
+                "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+              }
+            }
+          }
+  dataFrom:
+    - extract:
+        key: ghcr

--- a/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/stores/onepassword/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./clustersecretstore.yaml
+  - ./dockerhub-externalsecret.yaml
+  - ./ghcr-externalsecret.yaml
   - ./httproute.yaml
 
 configMapGenerator:

--- a/kubernetes/apps/flux-system/flux-instance/instance.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/instance.yaml
@@ -8,6 +8,7 @@ spec:
   distribution:
     version: "2.x"
     registry: "ghcr.io/fluxcd"
+    imagePullSecret: ghcr-credentials
   components:
     - source-controller
     - kustomize-controller

--- a/kubernetes/apps/home-automation/codeserver/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/codeserver/app/HelmRelease.yaml
@@ -25,6 +25,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       code:
         annotations:

--- a/kubernetes/apps/home-automation/esphome/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/esphome/app/HelmRelease.yaml
@@ -25,6 +25,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       esphome:
         annotations:

--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -26,6 +26,13 @@ spec:
     keepHistory: false
 
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+      securityContext:
+        fsGroup: 568
+        fsGroupChangePolicy: OnRootMismatch
+
     controllers:
       frigate:
         annotations:
@@ -69,10 +76,6 @@ spec:
               limits:
                 cpu: "2"
                 memory: 4Gi
-    defaultPodOptions:
-      securityContext:
-        fsGroup: 568
-        fsGroupChangePolicy: OnRootMismatch
     service:
       app:
         controller: frigate

--- a/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: home-assistant-green
   namespace: home-automation
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home-automation/home-assistant-db/migration/cluster-green.yaml
@@ -8,6 +8,8 @@ metadata:
   name: home-assistant-green
   namespace: home-automation
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/HelmRelease.yaml
@@ -25,6 +25,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       home-assistant:
         annotations:

--- a/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
@@ -81,6 +81,8 @@ spec:
     # thus we need the controller to be on the host network.
     # https://github.com/home-assistant-libs/python-matter-server?tab=readme-ov-file#requirements-to-communicate-with-thread-devices-through-thread-border-routers
     defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
 

--- a/kubernetes/apps/home-automation/n8n-db/app/cluster.yaml
+++ b/kubernetes/apps/home-automation/n8n-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: n8n-green
   namespace: home-automation
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home-automation/n8n-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home-automation/n8n-db/migration/cluster-green.yaml
@@ -16,6 +16,8 @@ metadata:
   name: n8n-green
   namespace: home-automation
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home-automation/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/paperless/app/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
     keepHistory: false
 
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       paperless:
         annotations:

--- a/kubernetes/apps/home/immich-db/app/cluster.yaml
+++ b/kubernetes/apps/home/immich-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name immich-green
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/immich-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home/immich-db/migration/cluster-green.yaml
@@ -8,6 +8,8 @@ metadata:
   name: immich-green
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/mealie-db/app/cluster.yaml
+++ b/kubernetes/apps/home/mealie-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name mealie-green
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/mealie-db/migration/cluster-green.yaml
+++ b/kubernetes/apps/home/mealie-db/migration/cluster-green.yaml
@@ -8,6 +8,8 @@ metadata:
   name: mealie-green
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mealie/app/helmrelease.yaml
@@ -27,6 +27,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       mealie:
         type: statefulset

--- a/kubernetes/apps/home/med-tracker-db/app/cluster.yaml
+++ b/kubernetes/apps/home/med-tracker-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name med-tracker
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -27,6 +27,10 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       med-tracker:
         type: deployment

--- a/kubernetes/apps/home/penpot-db/app/cluster.yaml
+++ b/kubernetes/apps/home/penpot-db/app/cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   name: &name penpot
   namespace: home
 spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
   imageCatalogRef:
     apiGroup: postgresql.cnpg.io
     kind: ClusterImageCatalog

--- a/kubernetes/apps/home/penpot/app/job-skip-onboarding.yaml
+++ b/kubernetes/apps/home/penpot/app/job-skip-onboarding.yaml
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/name: penpot-skip-onboarding
         app.kubernetes.io/instance: penpot
     spec:
+      imagePullSecrets:
+        - name: dockerhub-credentials
       restartPolicy: OnFailure
       securityContext:
         runAsUser: 1001

--- a/kubernetes/apps/kube-system/kube-vip/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/app/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
         app.kubernetes.io/name: kube-vip
         app.kubernetes.io/version: v1.0.4
     spec:
+      imagePullSecrets:
+        - name: ghcr-credentials
       containers:
         - name: kube-vip
           image: ghcr.io/kube-vip/kube-vip:v1.1.2

--- a/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/reflector/app/helmrelease.yaml
@@ -29,3 +29,6 @@ spec:
       retries: 3
   uninstall:
     keepHistory: false
+  values:
+    imagePullSecrets:
+      - name: dockerhub-credentials

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
     remediation:
       retries: 3
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       gatus:
         annotations:

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -17,6 +17,13 @@ spec:
     remediation:
       retries: 3
   values:
+    global:
+      imagePullSecrets:
+        - dockerhub-credentials
+    image:
+      pullSecrets:
+        - dockerhub-credentials
+
     replicas: 1
     podAnnotations:
       reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -32,6 +32,9 @@ spec:
     remediation:
       retries: 3
   values:
+    imagePullSecrets:
+      - name: dockerhub-credentials
+
     # Deploy in Single Binary mode
     deploymentMode: SingleBinary
 

--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -97,6 +97,8 @@ spec:
     alertmanager:
       enabled: true
       spec:
+        imagePullSecrets:
+          - name: dockerhub-credentials
         resources:
           requests:
             cpu: 25m

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
   uninstall:
     keepHistory: true
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: dockerhub-credentials
+
     controllers:
       cloudflared:
         replicas: 2

--- a/kubernetes/apps/network/echo-server/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo-server/app/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
     remediation:
       retries: 3
   values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
     controllers:
       echo-server:
         strategy: RollingUpdate

--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -24,6 +24,8 @@ spec:
       retries: 3
   values:
     fullnameOverride: *app
+    imagePullSecrets:
+      - name: ghcr-credentials
     logLevel: info
     provider:
       name: webhook

--- a/kubernetes/apps/network/traefik/app/HelmRelease.yaml
+++ b/kubernetes/apps/network/traefik/app/HelmRelease.yaml
@@ -21,6 +21,8 @@ spec:
       retries: 3
   values:
     deployment:
+      imagePullSecrets:
+        - name: dockerhub-credentials
       replicas: 2
 
     # Enable Gateway API provider

--- a/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
+++ b/kubernetes/apps/openebs-system/openebs/app/helmrelease.yaml
@@ -21,6 +21,13 @@ spec:
     remediation:
       retries: 3
   values:
+    imagePullSecrets:
+      - name: dockerhub-credentials
+
+    preUpgradeHook:
+      imagePullSecrets:
+        - name: dockerhub-credentials
+
     engines:
       local:
         lvm:
@@ -34,9 +41,24 @@ spec:
           enabled: false
 
     localpv-provisioner:
+      imagePullSecrets:
+        - name: dockerhub-credentials
       enabled: true
       hostpathClass:
         enabled: true
         name: openebs-hostpath
         isDefaultClass: false
         basePath: /var/openebs/local
+
+    loki:
+      imagePullSecrets:
+        - name: dockerhub-credentials
+      serviceAccount:
+        imagePullSecrets:
+          - name: dockerhub-credentials
+
+    alloy:
+      global:
+        image:
+          pullSecrets:
+            - name: dockerhub-credentials

--- a/kubernetes/apps/storage/longhorn/app/HelmRelease.yaml
+++ b/kubernetes/apps/storage/longhorn/app/HelmRelease.yaml
@@ -26,6 +26,10 @@ spec:
     keepHistory: false
 
   values:
+    global:
+      imagePullSecrets:
+        - dockerhub-credentials
+
     monitoring:
       enabled: true
       createPrometheusRules: true

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/app/config/values.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/app/config/values.yaml
@@ -1,5 +1,9 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-4.3.0/charts/other/app-template/values.schema.json
+defaultPodOptions:
+  imagePullSecrets:
+    - name: dockerhub-credentials
+
 controllers:
   system-upgrade-controller:
     strategy: RollingUpdate


### PR DESCRIPTION
## Summary
- add DockerHub and GHCR dockerconfig ExternalSecrets sourced from 1Password
- reflect registry credentials only into namespaces that need those registries
- wire DockerHub consumers to dockerhub-credentials and GHCR runtime pulls to ghcr-credentials

## Validation
- git diff --check
- task k8s:kubeconform
- pre-commit hooks during commit