### PR TITLE
feat: manage zitadel login key

### DIFF
--- a/kubernetes/apps/authentication/zitadel/README.md
+++ b/kubernetes/apps/authentication/zitadel/README.md
@@ -65,6 +65,17 @@ Configure the Google IDP in Zitadel console after deployment.
 Passkeys are enabled by default via the `PasswordlessType: 1` setting.
 Users can enroll passkeys from their account settings.
 
+## Certificates
+
+The public HTTPS certificate for `zitadel.damacus.io` is managed separately by
+the Gateway/Traefik path. Zitadel chart v10 also requires a Login UI service
+credential, but that keypair is not browser-facing TLS.
+
+The `zitadel-login-service-key` cert-manager `Certificate` creates a dedicated
+RSA `kubernetes.io/tls` Secret for the v10 Login UI JWT client assertion flow.
+The chart consumes it through `login.loginServiceKeySecretName`, mounting
+`tls.crt` into Zitadel and `tls.key` into `zitadel-login`.
+
 ## Access
 
 - Console: `https://zitadel.damacus.io`

--- a/kubernetes/apps/authentication/zitadel/app/certificate.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/certificate.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: zitadel-login-service-key
+  namespace: authentication
+spec:
+  secretName: zitadel-login-service-key
+  commonName: zitadel-login-client
+  privateKey:
+    algorithm: RSA
+    size: 2048
+    encoding: PKCS8
+    rotationPolicy: Always
+  usages:
+    - digital signature
+    - client auth
+  issuerRef:
+    name: selfsigned-issuer
+    kind: ClusterIssuer

--- a/kubernetes/apps/authentication/zitadel/app/helmrelease.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/helmrelease.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: zitadel
-      version: 9.34.1
+      version: 10.0.0
       sourceRef:
         kind: HelmRepository
         name: zitadel
@@ -100,6 +100,7 @@ spec:
 
     login:
       enabled: true
+      loginServiceKeySecretName: zitadel-login-service-key
       service:
         appProtocol: ""
 

--- a/kubernetes/apps/authentication/zitadel/app/kustomization.yaml
+++ b/kubernetes/apps/authentication/zitadel/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - certificate.yaml
   - externalsecret.yaml
   - helmrelease.yaml
   - httproute.yaml

--- a/kubernetes/apps/authentication/zitadel/ks.yaml
+++ b/kubernetes/apps/authentication/zitadel/ks.yaml
@@ -22,3 +22,4 @@ spec:
   dependsOn:
     - name: zitadel-db
     - name: external-secrets-stores
+    - name: cert-manager-issuers

--- a/kubernetes/apps/cert-manager/cert-manager/issuers/issuers.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/issuers/issuers.yaml
@@ -2,6 +2,13 @@
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
   name: letsencrypt-production
 spec:
   acme:

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -40,3 +40,5 @@ spec:
   interval: 30m
   retryInterval: 1m
   timeout: 5m
+  dependsOn:
+    - name: cert-manager


### PR DESCRIPTION
## Summary
- upgrade the ZITADEL HelmRelease to chart v10
- add a dedicated cert-manager RSA Certificate for the Login UI service key
- add a self-signed ClusterIssuer and Flux dependencies so the key is available before ZITADEL reconciles
- document the split between public HTTPS TLS and the internal Login UI signing key

## Validation
- task k8s:kubeconform
- task flux:local-test path=./kubernetes