### PR TITLE
fix: allow Forgejo SSH through Cilium

### DIFF
--- a/kubernetes/apps/dev/forgejo/app/ciliumnetworkpolicy.yaml
+++ b/kubernetes/apps/dev/forgejo/app/ciliumnetworkpolicy.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: forgejo-ssh-node-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: forgejo
+      app.kubernetes.io/name: forgejo
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "2222"
+              protocol: TCP

--- a/kubernetes/apps/dev/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/dev/forgejo/app/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ciliumnetworkpolicy.yaml
   - externalsecret.yaml
   - helmrelease.yaml
   - httproute.yaml


### PR DESCRIPTION
## Summary
- add a CiliumNetworkPolicy for Forgejo SSH ingress from Cilium host/remote-node entities
- include the policy in the Forgejo app kustomization

## Verification
- kubectl apply --dry-run=server -n dev -k kubernetes/apps/dev/forgejo/app
- confirmed SSH now reaches Forgejo; remaining push failure is the separate SHA-1 local repo vs SHA-256 remote repo object-format mismatch