### PR TITLE
fix: tune cnpg backup alerts

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -130,7 +130,22 @@ spec:
                         type: prometheus
                         uid: prometheus
                       editorMode: code
-                      expr: min by (namespace, job) (time() - cnpg_collector_last_available_backup_timestamp) > 90000
+                      expr: |-
+                        (
+                          min by (namespace, job) (
+                            time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{
+                              job!~"dev/forgejo-green|home-automation/(home-assistant-green|n8n-green)"
+                            }
+                          ) > 10800
+                        )
+                        or
+                        (
+                          min by (namespace, job) (
+                            time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{
+                              job=~"dev/forgejo-green|home-automation/(home-assistant-green|n8n-green)"
+                            }
+                          ) > 129600
+                        )
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -178,8 +193,8 @@ spec:
                 execErrState: Alerting
                 for: 15m
                 annotations:
-                  summary: CNPG backup age exceeds 25 hours
-                  description: At least one CNPG cluster has no recent successful backup.
+                  summary: CNPG backup age exceeds expected schedule
+                  description: A CNPG cluster has no recent successful Barman backup for its schedule.
                 labels:
                   severity: critical
               - uid: cnpg-recent-backup-failed
@@ -196,7 +211,17 @@ spec:
                         type: prometheus
                         uid: prometheus
                       editorMode: code
-                      expr: max by (namespace, job) (time() - cnpg_collector_last_failed_backup_timestamp) < 3600
+                      expr: |-
+                        (
+                          max by (namespace, job) (barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp)
+                          > max by (namespace, job) (barman_cloud_cloudnative_pg_io_last_available_backup_timestamp)
+                        )
+                        and on (namespace, job)
+                        (
+                          max by (namespace, job) (
+                            time() - barman_cloud_cloudnative_pg_io_last_failed_backup_timestamp
+                          ) < 3600
+                        )
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200


### PR DESCRIPTION
## Summary
- switch CNPG stale-backup alerts to Barman plugin backup timestamps
- use a 3-hour stale window for hourly CNPG backup schedules
- keep a 36-hour stale window for daily CNPG backup schedules
- only alert on recent backup failures when the failed backup is newer than the last successful backup

## Schedule check
Hourly jobs covered by the 3-hour threshold:
- authentication/zitadel-green: `0 4 * * *`
- home/immich-green: `0 3 * * *`
- home/mealie-green: `0 4 * * *`
- home/med-tracker: `0 4 * * *`
- home/penpot: `0 5 * * *`

Daily jobs covered by the 36-hour threshold:
- dev/forgejo-green: `0 0 0 * * *`
- home-automation/home-assistant-green: `0 0 0 * * *`
- home-automation/n8n-green: `0 0 0 * * *`

## Validation
- task k8s:kubeconform
- live VictoriaMetrics query for tuned stale-backup expression returned 0 firing series
- live VictoriaMetrics query for tuned recent-failure expression returned 0 firing series
- verified live ScheduledBackup cadences match the alert windows above