### PR TITLE
fix: reduce loki log noise

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -161,6 +161,9 @@ spec:
           access_log off;
 
     # Monitoring
+    lokiCanary:
+      enabled: false
+
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
@@ -87,6 +87,22 @@ spec:
           inputs: [remap_kubernetes_logs]
           condition: '.label.app == "home-assistant" && is_string(.message) && match(string!(.message), r''\\[bluetooth_auto_recovery\\.recover\\] Could not (determine the power state of|cycle|reset the power state of) the Bluetooth adapter hci1'')'
 
+        filter_ingested_logs:
+          type: filter
+          inputs: [remap_kubernetes_logs]
+          condition: |
+            !(
+              .label.namespace == "openebs-system" &&
+              .label.app == "loki" &&
+              is_string(.message) &&
+              (
+                contains(string!(.message), "caller=index_set.go") ||
+                contains(string!(.message), "caller=table_manager.go") ||
+                contains(string!(.message), "caller=recalculate_owned_streams.go") ||
+                contains(string!(.message), "caller=flush.go")
+              )
+            )
+
         home_assistant_bt_metric:
           type: log_to_metric
           inputs: [filter_home_assistant_bt]
@@ -100,7 +116,7 @@ spec:
       sinks:
         loki:
           type: loki
-          inputs: [remap_kubernetes_logs]
+          inputs: [filter_ingested_logs]
           endpoint: http://loki-gateway.monitoring.svc.cluster.local
           encoding:
             codec: json


### PR DESCRIPTION
## Summary
- disable the actual Loki canary workload with top-level lokiCanary.enabled=false
- route Vector ingestion through a narrow filter that drops OpenEBS Loki maintenance chatter
- keep OpenEBS warnings/errors and non-Loki OpenEBS component logs ingested

## Investigation
OpenEBS Loki was producing expected info-level internal maintenance logs from index_set.go, table_manager.go, recalculate_owned_streams.go, and flush.go. This appears to be upstream/runtime noise rather than a storage health issue, so the repo now filters those records locally until the upstream behavior changes.

## Validation
- task k8s:kubeconform
- helm template confirmed Loki canary resources are removed
- helm template confirmed Vector sink uses filter_ingested_logs

Note: task flux:local-test was not run because Docker socket escalation was rejected as too broad in Codex.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->