### PR TITLE
fix: allow penpot frontend ingress

### DIFF
--- a/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
+++ b/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
@@ -155,5 +155,5 @@ spec:
             k8s:app.kubernetes.io/instance: penpot
       toPorts:
         - ports:
-            - port: "80"
+            - port: "8080"
               protocol: TCP

--- a/kubernetes/apps/home/penpot/app/networkpolicy.yaml
+++ b/kubernetes/apps/home/penpot/app/networkpolicy.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json
-# Frontend: only Traefik may reach port 80
+# Frontend: only Traefik may reach the nginx pod port.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,7 +22,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: traefik
       ports:
-        - port: 80
+        - port: 8080
           protocol: TCP
     # Exporter's headless Chromium loads the frontend internally
     - from:
@@ -34,7 +34,7 @@ spec:
               app.kubernetes.io/controller: exporter
               app.kubernetes.io/instance: penpot
       ports:
-        - port: 80
+        - port: 8080
           protocol: TCP
 ---
 # yaml-language-server: $schema=https://kubernetesjsonschema.dev/v1.32.1/networkpolicy-networking-v1.json


### PR DESCRIPTION
## Summary
- allow Traefik and the Penpot exporter to reach the frontend pod on its actual target port 8080
- keep the Service and HTTPRoute on port 80 while matching NetworkPolicy/Cilium destination ports to the pod endpoint

## Debugging
- Penpot app pods and CNPG database were healthy in the home namespace
- public route returned HTTP 504 before the policy fix
- penpot-frontend Service exposes port 80 but targets pod port 8080
- stale Penpot policy resources in the default namespace were removed live
- stale duplicate home/penpot Flux Kustomization had no inventory and was removed live

## Validation
- task k8s:kubeconform
- https://penpot.ironstone.casa returns HTTP 200
- /api/rpc/command/get-profile returns HTTP 200 with Anonymous User payload
- Penpot backend recent logs show no Redis/errors after fix
- Alertmanager only reports Watchdog
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->