### PR TITLE
fix: enable penpot oidc login

### DIFF
--- a/kubernetes/apps/home/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/home/penpot/app/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
               repository: penpotapp/frontend
               tag: 2.15.4
             env:
-              PENPOT_FLAGS: enable-oidc enable-mcp disable-registration disable-email-verification disable-onboarding disable-onboarding-team
+              PENPOT_FLAGS: enable-login-with-oidc enable-oidc-registration enable-mcp disable-registration disable-email-verification disable-onboarding disable-onboarding-team
               PENPOT_BACKEND_URI: http://penpot-backend.home.svc.cluster.local:6060
               PENPOT_EXPORTER_URI: http://penpot-exporter.home.svc.cluster.local:6061
               PENPOT_MCP_URI: http://penpot-mcp.home.svc.cluster.local:4401
@@ -155,7 +155,7 @@ spec:
               repository: penpotapp/backend
               tag: 2.15.4
             env:
-              PENPOT_FLAGS: enable-oidc disable-registration disable-email-verification disable-onboarding disable-onboarding-team
+              PENPOT_FLAGS: enable-login-with-oidc enable-oidc-registration disable-registration disable-email-verification disable-onboarding disable-onboarding-team
               PENPOT_PUBLIC_URI: https://penpot.ironstone.casa
               PENPOT_DATABASE_URI: postgresql://penpot-rw.home.svc.cluster.local/penpot
               PENPOT_DATABASE_USERNAME: app
@@ -247,7 +247,7 @@ spec:
               repository: penpotapp/exporter
               tag: 2.15.4
             env:
-              PENPOT_FLAGS: enable-oidc disable-registration disable-email-verification disable-onboarding disable-onboarding-team
+              PENPOT_FLAGS: enable-login-with-oidc enable-oidc-registration disable-registration disable-email-verification disable-onboarding disable-onboarding-team
               # Exporter loads pages via headless Chromium; use the internal frontend service
               PENPOT_PUBLIC_URI: http://penpot-frontend.home.svc.cluster.local
               PENPOT_REDIS_URI: redis://redis-master.database.svc.cluster.local:6379/3
@@ -283,7 +283,6 @@ spec:
             fsGroup: 1001
             seccompProfile:
               type: RuntimeDefault
-
     service:
       frontend:
         controller: frontend

--- a/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
+++ b/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
@@ -89,6 +89,12 @@ spec:
         - ports:
             - port: "6379"
               protocol: TCP
+    - toFQDNs:
+        - matchName: zitadel.damacus.io
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toEndpoints:
         - matchLabels:
             k8s:io.kubernetes.pod.namespace: home


### PR DESCRIPTION
## Summary
- replace the invalid Penpot OIDC flag with documented login and OIDC self-registration flags
- allow the Penpot backend to reach Zitadel OIDC discovery over HTTPS
- preserve the existing frontend MCP flag while keeping the frontend on the 8080 listener/probes from main

## Validation
- task k8s:kubeconform
- flux reconcile helmrelease -n home penpot
- kubectl rollout status -n home deploy/penpot-frontend --timeout=180s
- kubectl rollout status -n home deploy/penpot-backend --timeout=180s
- kubectl rollout status -n home deploy/penpot-exporter --timeout=180s
- kubectl rollout status -n home deploy/penpot-mcp --timeout=180s
- Penpot HelmRelease Ready=True, release home/penpot.v49
- backend OIDC discovery reaches https://zitadel.damacus.io
- public /js/config.js exposes enable-login-with-oidc enable-oidc-registration enable-mcp
- Penpot profile count is 0, so no local email/password login exists yet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->