### PR TITLE
fix: restrict penpot mcp egress

### DIFF
--- a/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
+++ b/kubernetes/apps/home/penpot/app/networkpolicy-egress.yaml
@@ -46,6 +46,38 @@ spec:
               protocol: TCP
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# MCP egress: DNS + npm registry for startup-time corepack/npx package downloads
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: penpot-mcp-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/controller: mcp
+      app.kubernetes.io/instance: penpot
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s:k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+          rules:
+            dns:
+              - matchPattern: "*"
+    - toFQDNs:
+        - matchName: registry.npmjs.org
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
 # Backend egress: DNS + PostgreSQL + Redis + exporter
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy


### PR DESCRIPTION
## Summary
- add a dedicated CiliumNetworkPolicy for the Penpot MCP controller
- allow DNS and npm registry HTTPS egress so startup-time corepack/npx package downloads continue to work under egress enforcement

## Validation
- task k8s:kubeconform
- applied networkpolicy-egress.yaml live with server-side apply
- kubectl rollout restart -n home deploy/penpot-mcp
- kubectl rollout status -n home deploy/penpot-mcp --timeout=180s
- MCP logs showed pnpm and @penpot/mcp package download/build/startup completed
- from restarted MCP pod: registry.npmjs.org/pnpm returned 200
- from restarted MCP pod: registry.npmjs.org/@penpot%2fmcp returned 200
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->