### PR TITLE
fix: request penpot oidc email scope

### DIFF
--- a/kubernetes/apps/home/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/home/penpot/app/helmrelease.yaml
@@ -184,6 +184,7 @@ spec:
                     name: penpot-zitadel-oidc
                     key: client-secret
               PENPOT_OIDC_BASE_URI: https://zitadel.damacus.io
+              PENPOT_OIDC_SCOPES: openid profile email
               PENPOT_OIDC_NAME_ATTR: name
               PENPOT_OIDC_EMAIL_ATTR: email
             probes:


### PR DESCRIPTION
## Summary
- add the explicit `email` OIDC scope to Penpot backend configuration
- keep existing `name` and `email` claim mappings for Penpot profile creation

## Validation
- task k8s:kubeconform
- applied HelmRelease live with server-side apply
- flux reconcile helmrelease -n home penpot
- kubectl rollout status -n home deploy/penpot-backend --timeout=180s
- Penpot HelmRelease Ready=True, release home/penpot.v50
- live backend renders PENPOT_OIDC_SCOPES=openid profile email
- zitadel-tui confirms Penpot redirect URI is https://penpot.ironstone.casa/api/auth/oidc/callback
- recent Penpot backend logs show OIDC provider initialization and no new incomplete-user-info errors after rollout
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->