### PR TITLE
fix: use userinfo for penpot backend oidc

### DIFF
--- a/kubernetes/apps/home/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/home/penpot/app/helmrelease.yaml
@@ -193,6 +193,7 @@ spec:
                     key: client-secret
               PENPOT_OIDC_BASE_URI: https://zitadel.damacus.io
               PENPOT_OIDC_SCOPES: openid profile email
+              PENPOT_OIDC_USER_INFO_SOURCE: userinfo
               PENPOT_OIDC_NAME_ATTR: name
               PENPOT_OIDC_EMAIL_ATTR: email
             probes:


### PR DESCRIPTION
## Summary
- add PENPOT_OIDC_USER_INFO_SOURCE=userinfo to the Penpot backend controller
- keep the frontend env from #3653, but put the setting on the backend path that processes the OIDC callback

## Live remediation
- restored the Penpot Zitadel app OIDC assertions with zitadel-tui/API so idTokenUserinfoAssertion=true and refresh-token grant is preserved
- kept redirect URI as https://penpot.ironstone.casa/api/auth/oidc/callback

## Validation
- task k8s:kubeconform
- applied HelmRelease live with server-side apply
- flux reconcile helmrelease -n home penpot
- kubectl rollout status -n home deploy/penpot-backend --timeout=180s
- Penpot HelmRelease Ready=True, release home/penpot.v54
- live backend renders PENPOT_OIDC_USER_INFO_SOURCE=userinfo and PENPOT_OIDC_SCOPES=openid profile email
- recent backend logs have no new incomplete-user-info entries after rollout
- zitadel-tui confirms idTokenUserinfoAssertion=true for the Penpot app
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3654" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->