### PR TITLE
fix: disable kube-vip service security

### DIFF
--- a/ansible/playbooks/templates/custom-kube-vip-ds.yaml
+++ b/ansible/playbooks/templates/custom-kube-vip-ds.yaml
@@ -58,7 +58,7 @@ spec:
             - name: enable_endpointslices
               value: "true"
             - name: enable_service_security
-              value: "true"
+              value: "false"
             - name: vip_arpRate
               value: "3"
             - name: health_check_port

--- a/kubernetes/apps/kube-system/kube-vip/app/daemonset.yaml
+++ b/kubernetes/apps/kube-system/kube-vip/app/daemonset.yaml
@@ -72,7 +72,7 @@ spec:
             - name: enable_node_labeling
               value: "true"
             - name: enable_service_security
-              value: "true"
+              value: "false"
             - name: vip_arpRate
               value: "3"
             - name: health_check_port


### PR DESCRIPTION
## Summary
- Disable kube-vip service-security iptables management for the control-plane VIP in both GitOps and provisioning manifests.
- Keep kube-vip leader election and IPVS load balancing unchanged.

## Diagnosis
After the k3s `v1.36.1+k3s1` upgrade, direct API endpoints were healthy:

- `node-0b06a7` (`192.168.1.233`) returned HTTP 200 from `/healthz`
- `node-0b06df` (`192.168.1.27`) returned HTTP 200 from `/healthz`
- `node-0b0715` (`192.168.1.186`) returned HTTP 200 from `/healthz`

The control-plane VIP `192.168.1.220:6443` was unreachable. kube-vip logs showed local API downtime during the upgrade, backend removal, then VIP cleanup failing because kube-vip tried to run `iptables-legacy` while `enable_service_security=true`. The `plndr-cp-lock` lease stopped renewing until the kube-vip pods were restarted manually.

Disabling service security avoids that iptables cleanup path for this control-plane VIP, reducing the chance that a future upgrade leaves the VIP stuck after transient local API unavailability.

## Verification
- `task k8s:kubeconform`
- `task flux:local-test path=kubernetes/apps/kube-system/kube-vip`
- Live recovery after manual kube-vip pod restart: `192.168.1.220:6443/healthz` returned HTTP 200, kube-vip pods are Running/Ready, edge smoke passed, and Cilium operator recovered.
