### PR TITLE
fix: trim scheduler CPU requests

### DIFF
--- a/kubernetes/apps/keda/http-add-on/app/helmrelease.yaml
+++ b/kubernetes/apps/keda/http-add-on/app/helmrelease.yaml
@@ -27,10 +27,33 @@ spec:
   uninstall:
     keepHistory: false
   values:
+    operator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 500m
+          memory: 64Mi
+    scaler:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 500m
+          memory: 64Mi
     interceptor:
       replicas:
         min: 1
         max: 2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 20Mi
+        limits:
+          cpu: 500m
+          memory: 64Mi
       requestTimeout: 60s
       responseHeaderTimeout: 30s
       readinessTimeout: 60s

--- a/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/descheduler/app/helmrelease.yaml
@@ -25,6 +25,13 @@ spec:
   values:
     replicas: 2
     kind: Deployment
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
     deschedulerPolicyAPIVersion: descheduler/v1alpha2
     deschedulerPolicy:
       profiles:


### PR DESCRIPTION
## Summary
- reduce descheduler CPU requests from 500m to 100m per replica while preserving 500m burst limits
- reduce KEDA HTTP add-on operator, scaler, and interceptor CPU requests from 250m to 100m while preserving 500m burst limits
- leave Longhorn CPU allocations unchanged after checking historical instance-manager peaks

## Verification
- task k8s:kubeconform
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->