### PR TITLE
feat: add buildah forgejo runner

### DIFF
--- a/.github/workflows/forgejo-runner-buildah.yaml
+++ b/.github/workflows/forgejo-runner-buildah.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Forgejo Runner Buildah Image
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/forgejo-runner-buildah.yaml"
+      - "containers/forgejo-runner-buildah/**"
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - ".github/workflows/forgejo-runner-buildah.yaml"
+      - "containers/forgejo-runner-buildah/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.1.0
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish
+        uses: docker/build-push-action@v7.2.0
+        with:
+          context: containers/forgejo-runner-buildah
+          file: containers/forgejo-runner-buildah/Containerfile
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/damacus/forgejo-runner-buildah:0.1.0

--- a/containers/forgejo-runner-buildah/Containerfile
+++ b/containers/forgejo-runner-buildah/Containerfile
@@ -1,0 +1,27 @@
+FROM data.forgejo.org/forgejo/runner:12 AS forgejo-runner
+
+FROM quay.io/buildah/stable:v1.40.1
+
+RUN dnf install -y \
+      bash \
+      ca-certificates \
+      fuse-overlayfs \
+      git \
+      nodejs \
+      npm \
+      shadow-utils \
+      slirp4netns \
+    && dnf clean all \
+    && useradd --create-home --home-dir /home/runner --shell /bin/bash runner
+
+COPY --from=forgejo-runner /bin/forgejo-runner /usr/local/bin/forgejo-runner
+
+ENV HOME=/home/runner
+ENV STORAGE_DRIVER=vfs
+ENV BUILDAH_ISOLATION=chroot
+
+WORKDIR /home/runner
+USER runner
+
+ENTRYPOINT ["/usr/local/bin/forgejo-runner"]
+CMD ["daemon", "--config", "/config/runner-config.yml"]

--- a/docs/forgejo/buildah-runner.md
+++ b/docs/forgejo/buildah-runner.md
@@ -1,0 +1,33 @@
+# Forgejo Buildah Runner
+
+The in-cluster Forgejo runner is designed for workflows that can build
+containers with Buildah or ko without a Docker daemon. It intentionally avoids
+Docker-in-Docker and host socket mounts.
+
+Buildah needs user namespace syscalls for rootless builds. The Kubernetes pod is
+not privileged and does not mount host paths, but it uses an unconfined seccomp
+profile so `buildah bud --storage-driver=vfs --isolation=chroot` can run.
+
+Use the `buildah` runner label for Containerfile or Dockerfile builds:
+
+```yaml
+runs-on: buildah
+steps:
+  - uses: actions/checkout@v4
+  - run: buildah bud --storage-driver=vfs --isolation=chroot -t "$IMAGE" .
+  - run: buildah push "$IMAGE"
+```
+
+Go services can also use ko from a workflow if the repository installs or
+vendors it:
+
+```yaml
+runs-on: buildah
+steps:
+  - uses: actions/checkout@v4
+  - run: ko build ./cmd/app
+```
+
+Some third-party actions assume a Docker daemon. Those workflows should be
+rewritten for Buildah/ko or run on a separate Docker-capable runner outside the
+cluster.

--- a/kubernetes/apps/dev/forgejo-runner/app/deployment.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/app/deployment.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forgejo-runner-buildah
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: forgejo-runner-buildah
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: forgejo-runner-buildah
+      annotations:
+        reloader.stakater.com/auto: "true"
+    spec:
+      serviceAccountName: forgejo-runner-buildah
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: ghcr-credentials
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: Unconfined
+      containers:
+        - name: runner
+          image: ghcr.io/damacus/forgejo-runner-buildah:0.1.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ec
+          args:
+            - |
+              mkdir -p /tmp/run /home/runner/work
+              forgejo-runner daemon --config /config/runner-config.yml
+          env:
+            - name: HOME
+              value: /home/runner
+            - name: STORAGE_DRIVER
+              value: vfs
+            - name: BUILDAH_ISOLATION
+              value: chroot
+            - name: XDG_RUNTIME_DIR
+              value: /tmp/run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: home
+              mountPath: /home/runner
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: config
+          secret:
+            secretName: forgejo-runner
+            defaultMode: 0440
+        - name: home
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/kubernetes/apps/dev/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/app/externalsecret.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: forgejo-runner
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        runner-config.yml: |
+          log:
+            level: info
+            job_level: info
+
+          runner:
+            file: /home/runner/.runner
+            capacity: 1
+            envs:
+              STORAGE_DRIVER: vfs
+              BUILDAH_ISOLATION: chroot
+              XDG_RUNTIME_DIR: /tmp/run
+            timeout: 3h
+            shutdown_timeout: 3h
+            insecure: false
+            fetch_timeout: 30s
+            fetch_interval: 2s
+            report_interval: 1s
+            labels:
+              - self-hosted:host
+              - linux-arm64:host
+              - buildah:host
+
+          cache:
+            enabled: false
+
+          container:
+            privileged: false
+            options:
+            valid_volumes: []
+            docker_host: "-"
+
+          host:
+            workdir_parent: /home/runner/work
+
+          server:
+            connections:
+              forgejo:
+                url: http://forgejo-http.dev.svc.cluster.local:3000/
+                uuid: "{{ .uuid }}"
+                token: "{{ .token }}"
+  data:
+    - secretKey: uuid
+      remoteRef:
+        key: forgejo-runner
+        property: uuid
+    - secretKey: token
+      remoteRef:
+        key: forgejo-runner
+        property: token

--- a/kubernetes/apps/dev/forgejo-runner/app/kustomization.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - externalsecret.yaml
+  - serviceaccount.yaml

--- a/kubernetes/apps/dev/forgejo-runner/app/serviceaccount.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/app/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: forgejo-runner-buildah
+automountServiceAccountToken: false

--- a/kubernetes/apps/dev/forgejo-runner/ks.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: forgejo-runner
+  namespace: flux-system
+spec:
+  targetNamespace: dev
+  path: ./kubernetes/apps/dev/forgejo-runner/app
+  prune: true
+  dependsOn:
+    - name: external-secrets-stores
+    - name: forgejo
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/dev/forgejo-runner/tests/policy.mql.yaml
+++ b/kubernetes/apps/dev/forgejo-runner/tests/policy.mql.yaml
@@ -1,0 +1,150 @@
+---
+policies:
+  - uid: home-ops-forgejo-runner-buildah
+    name: Forgejo Buildah Runner
+    version: 1.0.0
+    scoring_system: highest impact
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: local
+    authors:
+      - name: Dan Webb
+        email: dan.webb@damacus.io
+    docs:
+      desc: |
+        Validates that the Forgejo runner uses Buildah without DIND,
+        Docker socket mounts, or privileged execution.
+    groups:
+      - title: Forgejo runner GitOps manifests
+        filters:
+          - mql: asset.family.contains("unix")
+        checks:
+          - uid: forgejo-runner-dev-kustomization
+          - uid: forgejo-runner-flux-kustomization
+          - uid: forgejo-runner-secret-config
+          - uid: forgejo-runner-buildah-deployment
+          - uid: forgejo-runner-buildah-safety
+          - uid: forgejo-runner-image-definition
+          - uid: forgejo-runner-image-publish-workflow
+    require:
+      - provider: os
+
+queries:
+  - uid: forgejo-runner-dev-kustomization
+    title: Dev namespace must include the Forgejo runner app
+    mql: |
+      dev = file("kubernetes/apps/dev/kustomization.yaml")
+      dev.exists
+      dev.content.contains("./forgejo-runner/ks.yaml")
+    docs:
+      desc: The dev app bundle must include the runner Flux Kustomization.
+
+  - uid: forgejo-runner-flux-kustomization
+    title: Forgejo runner Flux Kustomization must target dev
+    mql: |
+      ks = file("kubernetes/apps/dev/forgejo-runner/ks.yaml")
+      ks.exists
+      ks.content.contains("name: forgejo-runner")
+      ks.content.contains("namespace: flux-system")
+      ks.content.contains("targetNamespace: dev")
+      ks.content.contains("path: ./kubernetes/apps/dev/forgejo-runner/app")
+      ks.content.contains("name: external-secrets-stores")
+      ks.content.contains("name: forgejo")
+      ks.content.contains("wait: true")
+    docs:
+      desc: The runner must reconcile after Forgejo and External Secrets.
+
+  - uid: forgejo-runner-secret-config
+    title: Forgejo runner secret must render host-mode config
+    mql: |
+      secret = file("kubernetes/apps/dev/forgejo-runner/app/externalsecret.yaml")
+      secret.exists
+      secret.content.contains("kind: ExternalSecret")
+      secret.content.contains("name: forgejo-runner")
+      secret.content.contains("name: onepassword-connect")
+      secret.content.contains("key: forgejo-runner")
+      secret.content.contains("runner-config.yml")
+      secret.content.contains("http://forgejo-http.dev.svc.cluster.local:3000/")
+      secret.content.contains("capacity: 1")
+      secret.content.contains("self-hosted:host")
+      secret.content.contains("linux-arm64:host")
+      secret.content.contains("buildah:host")
+      secret.content.contains("docker://") == false
+    docs:
+      desc: The runner must use host labels and avoid Docker label backends.
+
+  - uid: forgejo-runner-buildah-deployment
+    title: Forgejo runner deployment must use the Buildah runner image
+    mql: |
+      deployment = file("kubernetes/apps/dev/forgejo-runner/app/deployment.yaml")
+      deployment.exists
+      deployment.content.contains("kind: Deployment")
+      deployment.content.contains("name: forgejo-runner-buildah")
+      deployment.content.contains("replicas: 1")
+      deployment.content.contains("image: ghcr.io/damacus/forgejo-runner-buildah:0.1.0")
+      deployment.content.contains("forgejo-runner daemon --config /config/runner-config.yml")
+      deployment.content.contains("STORAGE_DRIVER")
+      deployment.content.contains("vfs")
+      deployment.content.contains("BUILDAH_ISOLATION")
+      deployment.content.contains("chroot")
+      deployment.content.contains("cpu: 100m")
+      deployment.content.contains("memory: 256Mi")
+      deployment.content.contains("cpu: 2000m")
+      deployment.content.contains("memory: 2Gi")
+    docs:
+      desc: The runner pod must be small at rest and able to burst during builds.
+
+  - uid: forgejo-runner-buildah-safety
+    title: Forgejo runner must not use DIND, Docker sockets, or privileged mode
+    mql: |
+      deployment = file("kubernetes/apps/dev/forgejo-runner/app/deployment.yaml")
+      deployment.exists
+      deployment.content.contains("privileged: true") == false
+      deployment.content.contains("docker:dind") == false
+      deployment.content.contains("docker:28-dind") == false
+      deployment.content.contains("/var/run/docker.sock") == false
+      deployment.content.contains("hostPath") == false
+      deployment.content.contains("allowPrivilegeEscalation: false")
+      deployment.content.contains("readOnlyRootFilesystem: true")
+      deployment.content.contains("runAsNonRoot: true")
+      deployment.content.contains("type: Unconfined")
+    docs:
+      desc: The runner avoids Docker daemon and socket patterns, but Buildah requires unconfined seccomp for user namespaces.
+
+  - uid: forgejo-runner-image-definition
+    title: Buildah runner image definition must install expected tools
+    mql: |
+      image = file("containers/forgejo-runner-buildah/Containerfile")
+      image.exists
+      image.content.contains("quay.io/buildah/stable")
+      image.content.contains("data.forgejo.org/forgejo/runner")
+      image.content.contains("buildah")
+      image.content.contains("git")
+      image.content.contains("nodejs")
+      image.content.contains("npm")
+      image.content.contains("fuse-overlayfs")
+      image.content.contains("slirp4netns")
+      image.content.contains("STORAGE_DRIVER=vfs")
+      image.content.contains("BUILDAH_ISOLATION=chroot")
+      image.content.contains("USER runner")
+    docs:
+      desc: The custom image must include Forgejo Runner plus Buildah and workflow tools.
+
+  - uid: forgejo-runner-image-publish-workflow
+    title: Buildah runner image must have a GHCR publish workflow
+    mql: |
+      workflow = file(".github/workflows/forgejo-runner-buildah.yaml")
+      workflow.exists
+      workflow.content.contains("name: Forgejo Runner Buildah Image")
+      workflow.content.contains("packages: write")
+      workflow.content.contains("actions/checkout@v6.0.3")
+      workflow.content.contains("docker/setup-qemu-action@v4.1.0")
+      workflow.content.contains("docker/setup-buildx-action@v4.1.0")
+      workflow.content.contains("docker/login-action@v4.2.0")
+      workflow.content.contains("docker/build-push-action@v7.2.0")
+      workflow.content.contains("context: containers/forgejo-runner-buildah")
+      workflow.content.contains("file: containers/forgejo-runner-buildah/Containerfile")
+      workflow.content.contains("platforms: linux/arm64")
+      workflow.content.contains("ghcr.io/damacus/forgejo-runner-buildah:0.1.0")
+    docs:
+      desc: The custom image must be published by CI because cluster rollout depends on GHCR availability.

--- a/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/dev/forgejo/app/helmrelease.yaml
@@ -96,6 +96,11 @@ spec:
           PROVIDER: db
         queue:
           TYPE: level
+        actions:
+          ENABLED: "true"
+          DEFAULT_ACTIONS_URL: https://data.forgejo.org
+          LOG_RETENTION_DAYS: 30
+          ARTIFACT_RETENTION_DAYS: 30
         security:
           INSTALL_LOCK: "true"
         oauth2_client:

--- a/kubernetes/apps/dev/kustomization.yaml
+++ b/kubernetes/apps/dev/kustomization.yaml
@@ -4,5 +4,6 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./forgejo-db/ks.yaml
+  - ./forgejo-runner/ks.yaml
   - ./forgejo/ks.yaml
   - ./namespace.yaml


### PR DESCRIPTION
## Summary
- add a Buildah-first Forgejo runner image with Forgejo runner, Buildah, git, node, npm, and shell tooling
- add the Flux-managed dev runner app with host-mode labels, ExternalSecret config, non-privileged deployment, and no Docker socket or DIND sidecar
- enable Forgejo Actions and retention settings, document Buildah and ko workflow examples, and add a GHCR publish workflow

## Validation
- cnspec --auto-update=false policy lint kubernetes/apps/dev/forgejo-runner/tests/policy.mql.yaml
- cnspec --auto-update=false scan local --policy-bundle kubernetes/apps/dev/forgejo-runner/tests/policy.mql.yaml --incognito
- task k8s:kubeconform
- git diff --check
- yq '.' .github/workflows/forgejo-runner-buildah.yaml
- local image build and Buildah smoke test with seccomp=unconfined

## Notes
- local docker push to GHCR was blocked because the current GitHub token lacks write:packages; the added workflow publishes ghcr.io/damacus/forgejo-runner-buildah:0.1.0 with packages: write on main or manual dispatch
- existing code-server auth edits were left unstaged and are not included in this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->