### PR TITLE
fix(n8n): route mcp server endpoint

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -191,6 +191,9 @@ spec:
               - path:
                   type: PathPrefix
                   value: /webhook-waiting
+              - path:
+                  type: PathPrefix
+                  value: /mcp-server
             backendRefs:
               - kind: Service
                 name: n8n


### PR DESCRIPTION
## Summary
- route /mcp-server on n8n-webhooks.damacus.io to the n8n service
- keep existing /webhook, /webhook-test, and /webhook-waiting routes unchanged

## Verification
- yq parsed kubernetes/apps/home-automation/n8n/app/helmrelease.yaml successfully
- before: https://n8n-webhooks.damacus.io/mcp-server/http returned Traefik-style 404 page not found
- after live apply: https://n8n-webhooks.damacus.io/mcp-server/http returns 401 with Bearer realm="n8n MCP Server", matching the healthy unauthenticated n8n MCP response

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->