### PR TITLE
fix: route n8n oauth callback

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -194,6 +194,9 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp-server
+              - path:
+                  type: Exact
+                  value: /rest/oauth2-credential/callback
             backendRefs:
               - kind: Service
                 name: n8n


### PR DESCRIPTION
## Summary
- add an exact public route for n8n OAuth2 credential callbacks on n8n-webhooks.damacus.io
- keep the webhook host limited to webhook paths plus this callback path
- avoid exposing the full n8n /rest API or UI on the public webhook hostname

## Validation
- git diff --check -- kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
- pre-commit hooks passed during commit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->