### PR TITLE
fix: move n8n editor to damacus

### DIFF
--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -76,7 +76,8 @@ spec:
                   secretKeyRef:
                     name: n8n-secret
                     key: encryption_key
-              N8N_HOST: "n8n.ironstone.casa"
+              N8N_EDITOR_BASE_URL: "https://n8n.damacus.io"
+              N8N_HOST: "n8n.damacus.io"
               N8N_LOG_LEVEL: "info"
               N8N_LOG_OUTPUT: "console"
               N8N_PORT: &port 5678
@@ -155,15 +156,21 @@ spec:
     route:
       app:
         annotations:
-          external-dns.alpha.kubernetes.io/target: "traefik-int.ironstone.casa"
+          external-dns.alpha.kubernetes.io/target: "traefik-ext.damacus.io"
         hostnames:
-          - "n8n.ironstone.casa"
+          - "n8n.damacus.io"
         parentRefs:
           - name: traefik-internal
             namespace: network
             sectionName: websecure
         rules:
-          - matches:
+          - filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: oauth2-proxy-forward-auth
+            matches:
               - path:
                   type: PathPrefix
                   value: /
@@ -194,9 +201,6 @@ spec:
               - path:
                   type: PathPrefix
                   value: /mcp-server
-              - path:
-                  type: Exact
-                  value: /rest/oauth2-credential/callback
             backendRefs:
               - kind: Service
                 name: n8n


### PR DESCRIPTION
## Summary
- move the n8n editor/API canonical origin from n8n.ironstone.casa to n8n.damacus.io
- set N8N_EDITOR_BASE_URL so OAuth callbacks are generated on n8n.damacus.io while webhooks stay on n8n-webhooks.damacus.io
- protect the public editor route with oauth2-proxy forward-auth middleware
- keep n8n-webhooks.damacus.io limited to webhook and MCP paths by removing the OAuth callback route from the webhook host

## Network policy check
- n8n pod ingress remains restricted by NetworkPolicy to Traefik pods in the network namespace on TCP/5678
- n8n egress CiliumNetworkPolicy is unchanged

## Validation
- yq checked n8n env, route filters, webhook route matches, and NetworkPolicy selectors
- git diff --check
- pre-commit hooks passed during commit, including yamllint and Kubernetes secret scan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->