### PR TITLE
fix: add damacus oauth2 proxy

### DIFF
--- a/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
@@ -98,9 +98,75 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
             seccompProfile: { type: RuntimeDefault }
 
+      oauth2-proxy-damacus:
+        replicas: 2
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: quay.io/oauth2-proxy/oauth2-proxy
+              tag: v7.15.3
+            envFrom:
+              - secretRef:
+                  name: oauth2-proxy
+            args:
+              - --http-address=0.0.0.0:4180
+              - --provider=oidc
+              - --oidc-issuer-url=https://zitadel.damacus.io
+              - --redirect-url=https://auth.damacus.io/oauth2/callback
+              - --email-domain=*
+              - --scope=openid profile email groups
+              - --cookie-domain=.damacus.io
+              - --whitelist-domain=.damacus.io
+              - --cookie-secure=true
+              - --cookie-samesite=lax
+              - --cookie-refresh=1h
+              - --cookie-expire=8h
+              - --cookie-csrf-per-request=true
+              - --cookie-csrf-expire=5m
+              - --reverse-proxy=true
+              - --set-xauthrequest=true
+              - --set-authorization-header=true
+              - --pass-access-token=true
+              - --pass-authorization-header=true
+              - --skip-provider-button=true
+              - --upstream=static://202
+              - --standard-logging=true
+              - --request-logging=true
+              - --auth-logging=true
+            probes:
+              liveness: *probes
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                cpu: 500m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+        pod:
+          securityContext:
+            runAsUser: 2000
+            runAsGroup: 2000
+            runAsNonRoot: true
+            fsGroup: 2000
+            fsGroupChangePolicy: OnRootMismatch
+            seccompProfile: { type: RuntimeDefault }
+
     service:
       app:
         controller: oauth2-proxy
+        ports:
+          http:
+            port: *port
+      damacus:
+        controller: oauth2-proxy-damacus
         ports:
           http:
             port: *port

--- a/kubernetes/apps/authentication/oauth2-proxy/app/httproute.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/httproute.yaml
@@ -23,3 +23,28 @@ spec:
         - kind: Service
           name: oauth2-proxy
           port: 4180
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oauth2-proxy-damacus
+  namespace: authentication
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "traefik-ext.damacus.io"
+spec:
+  hostnames:
+    - auth.damacus.io
+  parentRefs:
+    - name: traefik-internal
+      namespace: network
+      sectionName: websecure
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - kind: Service
+          name: oauth2-proxy-damacus
+          port: 4180

--- a/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
@@ -20,6 +20,23 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
+  name: oauth2-proxy-damacus-forward-auth
+  namespace: home-automation
+spec:
+  forwardAuth:
+    address: http://oauth2-proxy-damacus.authentication.svc.cluster.local:4180/
+    trustForwardHeader: true
+    authResponseHeaders:
+      - Authorization
+      - X-Auth-Request-Access-Token
+      - X-Auth-Request-Email
+      - X-Auth-Request-Groups
+      - X-Auth-Request-Preferred-Username
+      - X-Auth-Request-User
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
   name: oauth2-proxy-auth-only
   namespace: home-automation
 spec:

--- a/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/n8n/app/helmrelease.yaml
@@ -169,7 +169,7 @@ spec:
                 extensionRef:
                   group: traefik.io
                   kind: Middleware
-                  name: oauth2-proxy-forward-auth
+                  name: oauth2-proxy-damacus-forward-auth
             matches:
               - path:
                   type: PathPrefix


### PR DESCRIPTION
## Summary
- add a dedicated oauth2-proxy deployment/service for damacus.io using auth.damacus.io and .damacus.io cookies
- keep the existing oauth2-proxy deployment for auth.ironstone.casa so current ironstone-protected apps continue to work
- add a public HTTPRoute for auth.damacus.io to the damacus oauth2-proxy service
- add a home-automation Traefik middleware pointing at the damacus oauth2-proxy service
- switch n8n.damacus.io to use the damacus-specific middleware

## Zitadel
- updated the existing Zitadel oauth2-proxy app to allow both callbacks:
  - https://auth.ironstone.casa/oauth2/callback
  - https://auth.damacus.io/oauth2/callback
- updated allowed origins to include both auth hosts

## Network policy check
- n8n pod ingress remains restricted to Traefik pods in the network namespace on TCP/5678
- n8n webhook host remains limited to webhook/MCP paths from PR #3727

## Validation
- zitadel-tui apps list confirmed oauth2-proxy redirect URIs and allowed origins
- yq validated oauth2-proxy controllers/services, auth routes, n8n middleware reference, and n8n NetworkPolicy selectors
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3729" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->