### PR TITLE
fix: enforce damacus oauth group authorization

### DIFF
--- a/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml
@@ -117,6 +117,8 @@ spec:
               - --redirect-url=https://auth.damacus.io/oauth2/callback
               - --email-domain=*
               - --scope=openid profile email groups
+              - --oidc-groups-claim=groups
+              - --allowed-group=user
               - --cookie-domain=.damacus.io
               - --whitelist-domain=.damacus.io
               - --cookie-secure=true


### PR DESCRIPTION
### Motivation
- Close an authorization gap where the public `oauth2-proxy-damacus` accepted any Zitadel-authenticated identity due to `--email-domain=*` while not enforcing the repository's approved `groups` claim.

### Description
- Add `--oidc-groups-claim=groups` and `--allowed-group=user` to the `oauth2-proxy-damacus` HelmRelease args so the proxy requires the Zitadel `groups` claim and enforces membership in the `user` group.

### Testing
- Ran a targeted Python check that verified the HelmRelease args include `--email-domain=*`, `--scope=openid profile email groups`, `--oidc-groups-claim=groups`, and `--allowed-group=user`, and it passed.
- Parsed `kubernetes/apps/authentication/oauth2-proxy/app/helmrelease.yaml` as YAML to validate structure, and it passed.
- Ran `git diff --check` to confirm the patch is clean, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a7ad5c8d483229dc2ce61e03e2902)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3736" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->