### PR TITLE
fix: restrict gatus sidecar discovery

### DIFF
--- a/.github/workflows/flux.yaml
+++ b/.github/workflows/flux.yaml
@@ -164,22 +164,22 @@ jobs:
             -o github > flate.diff
           if [[ -s flate.diff ]]; then
             {
-              echo 'diff<<EOF'
+              echo '`````diff'
               cat flate.diff
-              echo 'EOF'
-            } >> "$GITHUB_OUTPUT"
+              echo '`````'
+            } > flate-comment.md
+            echo 'has_diff=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_diff=false' >> "$GITHUB_OUTPUT"
           fi
 
       - name: PR Comment
         uses: mshick/add-pr-comment@v3
-        if: ${{ steps.diff.outputs.diff != '' }}
+        if: ${{ steps.diff.outputs.has_diff == 'true' }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           message-failure: Unable to post flate diff
-          message: |
-            `````diff
-            ${{ steps.diff.outputs.diff }}
-            `````
+          message-path: flate-comment.md
 
   flate-success:
     if: ${{ always() }}

--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -47,8 +47,8 @@ spec:
           auto: false
           prefix: ""
         httproute:
-          enable: false
-          auto: true
+          enable: true
+          auto: false
           prefix: ""
         service:
           enable: false


### PR DESCRIPTION
## Summary
- keep gatus-sidecar watching HTTPRoutes but switch it to annotation-only emission
- prevents stale/unmanaged HTTPRoutes from generating duplicate Gatus endpoint names
- preserves the annotated Home Assistant and Echo Server checks

## Cluster evidence
- Gatus pod is CrashLoopBackOff in monitoring
- Gatus exits with: invalid endpoint _github-webhook: name and group combination must be unique
- Live cluster has two HTTPRoutes named github-webhook on flux-webhook.damacus.io, including a stale unmanaged home-automation route

## Verification
- kustomize build kubernetes/apps/monitoring/gatus/app --load-restrictor=LoadRestrictionsNone
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3762" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->