### PR TITLE
fix: harden hubble and frigate

### DIFF
--- a/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
+++ b/kubernetes/apps/authentication/oauth2-proxy/app/middlewares.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: home-automation
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -40,7 +40,7 @@ metadata:
   namespace: home-automation
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/oauth2/auth
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -57,7 +57,7 @@ metadata:
   namespace: home
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -74,7 +74,7 @@ metadata:
   namespace: home
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/oauth2/auth
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -91,7 +91,7 @@ metadata:
   namespace: monitoring
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -108,7 +108,7 @@ metadata:
   namespace: monitoring
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/oauth2/auth
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -125,7 +125,7 @@ metadata:
   namespace: storage
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -142,7 +142,7 @@ metadata:
   namespace: storage
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/oauth2/auth
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -159,7 +159,7 @@ metadata:
   namespace: kube-system
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization
@@ -176,7 +176,7 @@ metadata:
   namespace: kube-system
 spec:
   forwardAuth:
-    address: http://oauth2-proxy.authentication.svc.cluster.local:4180/oauth2/auth
+    address: http://oauth2-proxy-app.authentication.svc.cluster.local:4180/oauth2/auth
     trustForwardHeader: true
     authResponseHeaders:
       - Authorization

--- a/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml
@@ -67,6 +67,10 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
             securityContext:
+              # SECURITY EXCEPTION: Frigate's Rockchip RK3588 hardware
+              # acceleration currently requires privileged mode with explicit
+              # host device mounts. Keep this exception documented and covered by
+              # kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml.
               privileged: true
             resources:
               requests:

--- a/kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml
+++ b/kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml
@@ -1,0 +1,67 @@
+---
+policies:
+  - uid: home-ops-frigate-isolation
+    name: Frigate Isolation Controls
+    version: 1.0.0
+    scoring_system: highest impact
+    tags:
+      mondoo.com/category: security
+      mondoo.com/platform: local
+    authors:
+      - name: Dan Webb
+        email: dan.webb@damacus.io
+    docs:
+      desc: |
+        Validates that Frigate's privileged hardware-access exception is
+        documented and limited to the expected host device mounts.
+    groups:
+      - title: Frigate GitOps manifests
+        filters:
+          - mql: asset.family.contains("unix")
+        checks:
+          - uid: frigate-privileged-exception-documented
+          - uid: frigate-hostpath-allowlist
+          - uid: frigate-sys-hostpath-readonly
+    require:
+      - provider: os
+
+queries:
+  - uid: frigate-privileged-exception-documented
+    title: Frigate privileged mode must be an intentional exception
+    mql: |
+      helmrelease = file("kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml")
+      helmrelease.exists
+      helmrelease.content.contains("privileged: true")
+      helmrelease.content.contains("SECURITY EXCEPTION")
+      helmrelease.content.contains("Rockchip RK3588")
+      helmrelease.content.contains("kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml")
+    docs:
+      desc: Frigate currently needs privileged mode for hardware acceleration, so the exception must be documented beside the setting.
+
+  - uid: frigate-hostpath-allowlist
+    title: Frigate hostPath mounts must stay on the hardware allowlist
+    mql: |
+      helmrelease = file("kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml")
+      helmrelease.exists
+      helmrelease.content.contains("hostPath: /dev/bus/usb")
+      helmrelease.content.contains("hostPath: /dev/dri")
+      helmrelease.content.contains("hostPath: /dev/dma_heap")
+      helmrelease.content.contains("hostPath: /dev/rga")
+      helmrelease.content.contains("hostPath: /dev/mpp_service")
+      helmrelease.content.contains("hostPath: /sys")
+      helmrelease.content.contains("hostPath: /etc") == false
+      helmrelease.content.contains("hostPath: /var/run/docker.sock") == false
+      helmrelease.content.contains("hostPath: /var/lib/kubelet") == false
+      helmrelease.content.contains("hostPath: /root") == false
+    docs:
+      desc: Frigate may mount only the expected video/NPU device paths and read-only sysfs.
+
+  - uid: frigate-sys-hostpath-readonly
+    title: Frigate /sys hostPath must remain read-only
+    mql: |
+      helmrelease = file("kubernetes/apps/home-automation/frigate/app/HelmRelease.yaml")
+      helmrelease.exists
+      helmrelease.content.contains("hostPath: /sys")
+      helmrelease.content.contains("- path: /sys\n            readOnly: true")
+    docs:
+      desc: Frigate can inspect sysfs for hardware acceleration, but must not receive writable /sys.

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -10,7 +10,13 @@ spec:
       namespace: network
       sectionName: websecure
   rules:
-    - backendRefs:
+    - filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: traefik.io
+            kind: Middleware
+            name: oauth2-proxy-forward-auth
+      backendRefs:
         - name: hubble-ui
           port: 80
       matches:


### PR DESCRIPTION
## Summary
- Add OAuth2 forward-auth to the Hubble UI HTTPRoute.
- Update namespace-local OAuth2 proxy middlewares to target the rendered oauth2-proxy-app service.
- Keep Frigate privileged for Rockchip hardware acceleration, with an explicit exception comment and Mondoo policy coverage for host-path boundaries.

## Scope notes
- 1Password Connect is not user-facing, so it is left unauthenticated by oauth2-proxy-forward-auth.
- Frigate node selectors are omitted because all current nodes are Rockchip nodes and selector pinning adds noise.

## Tests
- cnspec --auto-update=false policy lint kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml
- cnspec --auto-update=false scan local --policy-bundle kubernetes/apps/home-automation/frigate/tests/policy.mql.yaml --incognito
- task flux:flate-test
- task kubernetes:yayamlls
- git diff --check