### PR TITLE
fix: disable Traefik API guard

### DIFF
--- a/kubernetes/apps/network/traefik/app/HelmRelease.yaml
+++ b/kubernetes/apps/network/traefik/app/HelmRelease.yaml
@@ -120,6 +120,7 @@ spec:
     metrics:
       prometheus:
         enabled: true
+        disableAPICheck: true
         serviceMonitor:
           enabled: true
           namespace: monitoring


### PR DESCRIPTION
## Summary
- Add metrics.prometheus.disableAPICheck for the Traefik HelmRelease.
- Keep the Traefik ServiceMonitor enabled in the monitoring namespace.
- Avoid changing Prometheus Operator CRDs, metrics, or the validation harness.

## Verification
- git diff --check
- task kubernetes:yayamlls exits 0, but still prints the same Traefik flate render diagnostic from a stale baseline/render context that does not include this new value.