### PR TITLE
fix(med-tracker): deploy auth bootstrap repair

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,12 +46,13 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.1
+              tag: &tag sha-8661aa8d76d86a7f37f42f9f16515bf10cf9b692
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:
                   name: med-tracker-secret
             env:
+              DATABASE_ROLE: med_tracker_owner
               RAILS_ENV: production
               TZ: "Europe/London"
         containers:


### PR DESCRIPTION
## Summary
- deploy med-tracker image sha-8661aa8d76d86a7f37f42f9f16515bf10cf9b692, which contains damacus/med-tracker#1403
- run the med-tracker migrate init container with DATABASE_ROLE=med_tracker_owner so the account bootstrap migration can complete

## Live context
- production was still serving ghcr.io/damacus/med-tracker:0.5.1
- direct HelmRelease patch was reverted by Flux because Git still declared 0.5.1
- migration initially failed because med_tracker_owner lacked platform_admins privileges; the live DB owner-role grants have been repaired

## Validation
- task flux:flate-test