### PR TITLE
fix(med-tracker): disable unconfigured otel exporter

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -53,6 +53,7 @@ spec:
                   name: med-tracker-secret
             env:
               DATABASE_ROLE: med_tracker_owner
+              OTEL_TRACES_EXPORTER: none
               RAILS_ENV: production
               TZ: "Europe/London"
         containers:
@@ -68,6 +69,7 @@ spec:
               RAILS_ENV: production
               RAILS_FORCE_SSL: "false"
               RAILS_LOG_LEVEL: info
+              OTEL_TRACES_EXPORTER: none
               SOLID_QUEUE_IN_PUMA: "true"
               TZ: "Europe/London"
               APP_URL: "https://med-tracker.damacus.io"


### PR DESCRIPTION
## Summary
- set OTEL_TRACES_EXPORTER=none for the med-tracker app and migrate init container
- prevents OpenTelemetry Ruby from registering the default OTLP exporter to localhost:4318 when no collector endpoint is configured

## Live context
- after deploying damacus/home-ops#3780, auth bootstrap is fixed but live logs still showed repeated OpenTelemetry export failures
- the running pod has no OTEL_* endpoint configuration
- a live runner with OTEL_TRACES_EXPORTER=none registered zero span processors

## Validation
- git diff --check
- yq inspected app and migrate env blocks
- task flux:flate-test (first run hit transient unrelated chart-resolution pendings for keda and metrics-server; immediate rerun passed: 172 passed, existing warnings only)