### PR TITLE
feat: add med tracker canary lane

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -5,6 +5,9 @@ version: "3"
 vars:
   CLUSTER_HEALTH_SCRIPT: "{{.SCRIPTS_DIR}}/cluster-health.py"
   MONDOO_SCAN_SCRIPT: "{{.SCRIPTS_DIR}}/mondoo_scan.py"
+  MED_TRACKER_CANARY_APP: "{{.KUBERNETES_DIR}}/apps/home/med-tracker-canary/app"
+  MED_TRACKER_CANARY_DB: "{{.KUBERNETES_DIR}}/apps/home/med-tracker-canary-db/app"
+  GATUS_CONFIG: "{{.KUBERNETES_DIR}}/apps/monitoring/gatus/app/resources/config.yaml"
   RUSTFS_IAM_POLICY: "{{.ROOT_DIR}}/tests/mondoo/rustfs-iam.mql.yaml"
   RUSTFS_IAM_LIVE_POLICY: "{{.ROOT_DIR}}/tests/mondoo/rustfs-iam-live.mql.yaml"
   RUSTFS_IAM_LIVE_CHECK_SCRIPT: "{{.SCRIPTS_DIR}}/rustfs_iam_live_check.sh"
@@ -181,6 +184,44 @@ tasks:
       - { msg: "Missing jq", sh: "command -v jq >/dev/null" }
       - { msg: "Missing RustFS live IAM policy", sh: "test -f {{.RUSTFS_IAM_LIVE_POLICY}}" }
       - { msg: "Missing RustFS live IAM check script", sh: "test -f {{.RUSTFS_IAM_LIVE_CHECK_SCRIPT}}" }
+
+  med-tracker-canary-isolation:
+    desc: Assert Med Tracker canary uses isolated app, storage, route, and database resources
+    cmds:
+      - yq -e '.metadata.name == "med-tracker-canary" and .spec.values.controllers."med-tracker-canary".containers.app.env.APP_URL == "https://med-tracker-canary.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.OIDC_REDIRECT_URI == "https://med-tracker-canary.damacus.io/auth/oidc/callback"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.SMTP_ENABLED == "false" and .spec.values.controllers."med-tracker-canary".containers.app.env.PUSH_NOTIFICATIONS_ENABLED == "false"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker-canary".initContainers.migrate.envFrom[0].secretRef.name == "med-tracker-canary-secret"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.envFrom[0].secretRef.name == "med-tracker-canary-secret"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.persistence.storage.existingClaim == "med-tracker-canary-storage"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.route.external.hostnames[0] == "med-tracker-canary.damacus.io" and .spec.values.route.external.annotations."external-dns.alpha.kubernetes.io/target" == "traefik-ext.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.route.external.rules[] | select(.matches[0].path.value == "/" and .filters[0].extensionRef.name == "oauth2-proxy-damacus-forward-auth" and .backendRefs[0].name == "med-tracker-canary")' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.route.external.rules[] | select(.matches[0].path.value == "/up" and .backendRefs[0].name == "med-tracker-canary")' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.route.external.rules[] | select(.matches[0].path.value == "/login" and .backendRefs[0].name == "med-tracker-canary")' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.target.name == "med-tracker-canary-secret"' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.dataFrom[] | select(.extract.key == "zitadel-med-tracker-canary-oidc")' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.DATABASE_URL | contains("@med-tracker-canary-rw.home.svc.cluster.local:5432/")' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_CACHE_DATABASE_URL | contains("@med-tracker-canary-rw.home.svc.cluster.local:5432/")' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_QUEUE_DATABASE_URL | contains("@med-tracker-canary-rw.home.svc.cluster.local:5432/")' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_CABLE_DATABASE_URL | contains("@med-tracker-canary-rw.home.svc.cluster.local:5432/")' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.DATABASE_URL | contains("med-tracker-rw.home.svc.cluster.local") | not' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_CACHE_DATABASE_URL | contains("med-tracker-rw.home.svc.cluster.local") | not' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_QUEUE_DATABASE_URL | contains("med-tracker-rw.home.svc.cluster.local") | not' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.spec.target.template.data.SOLID_CABLE_DATABASE_URL | contains("med-tracker-rw.home.svc.cluster.local") | not' {{.MED_TRACKER_CANARY_APP}}/externalsecret.yaml
+      - yq -e '.metadata.name == "med-tracker-canary" and .spec.bootstrap.recovery.source == "med-tracker-production-backup"' {{.MED_TRACKER_CANARY_DB}}/cluster.yaml
+      - yq -e '.spec.bootstrap.recovery.database == "med-tracker" and .spec.bootstrap.recovery.owner == "med-tracker" and .spec.bootstrap.recovery.secret.name == "med-tracker-canary-db"' {{.MED_TRACKER_CANARY_DB}}/cluster.yaml
+      - yq -e '.spec.plugins[] | select(.name == "barman-cloud.cloudnative-pg.io" and .isWALArchiver == true and .parameters.barmanObjectName == "med-tracker-canary-rustfs-store" and .parameters.serverName == "med-tracker-canary")' {{.MED_TRACKER_CANARY_DB}}/cluster.yaml
+      - yq -e '.spec.externalClusters[] | select(.name == "med-tracker-production-backup" and .plugin.name == "barman-cloud.cloudnative-pg.io" and .plugin.parameters.barmanObjectName == "med-tracker-rustfs-store" and .plugin.parameters.serverName == "med-tracker")' {{.MED_TRACKER_CANARY_DB}}/cluster.yaml
+      - yq -e '.metadata.name == "med-tracker-canary" and .spec.bootstrap.initdb == null' {{.MED_TRACKER_CANARY_DB}}/cluster.yaml
+      - yq -e '.metadata.name == "med-tracker-canary-rustfs-store" and .spec.configuration.destinationPath == "s3://cnpg-med-tracker-canary/"' {{.MED_TRACKER_CANARY_DB}}/objectstore.yaml
+      - yq -e '.spec.configuration.s3Credentials.accessKeyId.name == "rustfs-cnpg-med-tracker-canary" and .spec.configuration.s3Credentials.secretAccessKey.name == "rustfs-cnpg-med-tracker-canary"' {{.MED_TRACKER_CANARY_DB}}/objectstore.yaml
+      - yq -e '.endpoints[] | select(.name == "Med Tracker Canary Up" and .url == "https://med-tracker-canary.damacus.io/up")' {{.GATUS_CONFIG}}
+      - yq -e '.endpoints[] | select(.name == "Med Tracker Canary Login" and .url == "https://med-tracker-canary.damacus.io/login")' {{.GATUS_CONFIG}}
+    preconditions:
+      - { msg: "Missing yq", sh: "command -v yq >/dev/null" }
+      - { msg: "Missing Med Tracker canary app manifests", sh: "test -f {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml" }
+      - { msg: "Missing Med Tracker canary DB manifests", sh: "test -f {{.MED_TRACKER_CANARY_DB}}/cluster.yaml" }
+      - { msg: "Missing Gatus config", sh: "test -f {{.GATUS_CONFIG}}" }
 
   mondoo-operator-assertions:
     desc: Assert the Mondoo Operator GitOps manifests are wired safely

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -7,6 +7,8 @@ resources:
   - ./mealie-db/ks.yaml
   - ./mealie/ks.yaml
   - ./memos/ks.yaml
+  - ./med-tracker-canary-db/ks.yaml
+  - ./med-tracker-canary/ks.yaml
   - ./med-tracker-db/ks.yaml
   - ./med-tracker/ks.yaml
   - ./namespace.yaml

--- a/kubernetes/apps/home/med-tracker-canary-db/app/PrometheusRules.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/PrometheusRules.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: med-tracker-canary-db-rules
+  labels:
+    prometheus: k8s
+    role: alert-rules
+spec:
+  groups:
+    - name: cloudnative-pg.rules
+      rules:
+        - alert: LongRunningTransaction
+          annotations:
+            description: Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.
+            summary: A query is taking longer than 5 minutes.
+          expr: |-
+            cnpg_backends_max_tx_duration_seconds > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: BackendsWaiting
+          annotations:
+            description: Pod {{ $labels.pod }} has been waiting for longer than 5 minutes
+            summary: If a backend is waiting for longer than 5 minutes
+          expr: |-
+            cnpg_backends_waiting_total > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: PGDatabase
+          annotations:
+            description: Over 150,000,000 transactions from frozen xid on pod {{ $labels.pod }}
+            summary: Number of transactions from the frozen XID to the current one
+          expr: |-
+            cnpg_pg_database_xid_age > 150000000
+          for: 1m
+          labels:
+            severity: warning
+        - alert: PGReplication
+          annotations:
+            description: Standby is lagging behind by over 300 seconds (5 minutes)
+            summary: The standby is lagging behind the primary
+          expr: |-
+            cnpg_pg_replication_lag > 300
+          for: 1m
+          labels:
+            severity: warning
+        - alert: LastFailedArchiveTime
+          annotations:
+            description: Archiving failed for {{ $labels.pod }}
+            summary: Checks the last time archiving failed. Will be < 0 when it has not failed.
+          expr: |-
+            (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1
+          for: 1m
+          labels:
+            severity: warning
+        - alert: DatabaseDeadlockConflicts
+          annotations:
+            description: There are over 10 deadlock conflicts in {{ $labels.pod }}
+            summary: Checks the number of database conflicts
+          expr: |-
+            cnpg_pg_stat_database_deadlocks > 10
+          for: 1m
+          labels:
+            severity: warning

--- a/kubernetes/apps/home/med-tracker-canary-db/app/cluster.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/cluster.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: &name med-tracker-canary
+  namespace: home
+spec:
+  imagePullSecrets:
+    - name: ghcr-credentials
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql
+    major: 18
+  instances: 2
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 5Gi
+    storageClass: openebs-hostpath
+
+  monitoring:
+    enablePodMonitor: true
+
+  bootstrap:
+    recovery:
+      source: med-tracker-production-backup
+      database: med-tracker
+      owner: med-tracker
+      secret:
+        name: med-tracker-canary-db
+
+  enableSuperuserAccess: true
+  superuserSecret:
+    name: med-tracker-canary-db-superuser
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: 128MB
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: med-tracker-canary-rustfs-store
+        serverName: med-tracker-canary
+
+  externalClusters:
+    - name: med-tracker-production-backup
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: med-tracker-rustfs-store
+          serverName: med-tracker
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 2000m
+      memory: 512Mi

--- a/kubernetes/apps/home/med-tracker-canary-db/app/databases.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/databases.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: med-tracker-canary-cache
+  namespace: home
+spec:
+  name: medtracker_production_cache
+  owner: med-tracker
+  cluster:
+    name: med-tracker-canary
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: med-tracker-canary-queue
+  namespace: home
+spec:
+  name: medtracker_production_queue
+  owner: med-tracker
+  cluster:
+    name: med-tracker-canary
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: med-tracker-canary-cable
+  namespace: home
+spec:
+  name: medtracker_production_cable
+  owner: med-tracker
+  cluster:
+    name: med-tracker-canary

--- a/kubernetes/apps/home/med-tracker-canary-db/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/externalsecret.yaml
@@ -1,0 +1,63 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: med-tracker-canary-db
+  namespace: home
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: med-tracker-canary-db
+    template:
+      data:
+        username: "med-tracker"
+        password: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: med-tracker-canary-db
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: med-tracker-canary-db-superuser
+  namespace: home
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: med-tracker-canary-db-superuser
+    template:
+      data:
+        username: "postgres"
+        password: "{{ .superuser_password }}"
+  dataFrom:
+    - extract:
+        key: med-tracker-canary-db
+        property: superuser_password
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rustfs-cnpg-med-tracker-canary
+  namespace: home
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: rustfs-cnpg-med-tracker-canary
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        ACCESS_KEY_ID: "{{ .username }}"
+        SECRET_ACCESS_KEY: "{{ .password }}"
+  dataFrom:
+    - extract:
+        key: rustfs-cnpg-med-tracker-canary

--- a/kubernetes/apps/home/med-tracker-canary-db/app/kustomization.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - cluster.yaml
+  - databases.yaml
+  - externalsecret.yaml
+  - PrometheusRules.yaml
+  - objectstore.yaml
+  - scheduledbackup.yaml

--- a/kubernetes/apps/home/med-tracker-canary-db/app/objectstore.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/objectstore.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: med-tracker-canary-rustfs-store
+  namespace: home
+spec:
+  retentionPolicy: 30d
+  configuration:
+    destinationPath: s3://cnpg-med-tracker-canary/
+    endpointURL: http://rustfs.storage.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: rustfs-cnpg-med-tracker-canary
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: rustfs-cnpg-med-tracker-canary
+        key: SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 2

--- a/kubernetes/apps/home/med-tracker-canary-db/app/scheduledbackup.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/app/scheduledbackup.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: med-tracker-canary-db
+  namespace: home
+spec:
+  schedule: "0 55 3 * * *"
+  immediate: true
+  backupOwnerReference: self
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+    parameters:
+      objectStore: med-tracker-canary-rustfs-store
+  cluster:
+    name: med-tracker-canary

--- a/kubernetes/apps/home/med-tracker-canary-db/ks.yaml
+++ b/kubernetes/apps/home/med-tracker-canary-db/ks.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: med-tracker-canary-db
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  path: ./kubernetes/apps/home/med-tracker-canary-db/app
+  prune: true
+  dependsOn:
+    - name: cloudnative-pg
+    - name: openebs
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/home/med-tracker-canary/README.md
+++ b/kubernetes/apps/home/med-tracker-canary/README.md
@@ -1,0 +1,31 @@
+# Med Tracker Canary
+
+This lane is for risky Med Tracker application and security upgrades. It uses
+the same application image stream as production, but every mutable runtime
+resource is canary-specific:
+
+- `med-tracker-canary-secret`
+- `med-tracker-canary-storage`
+- `med-tracker-canary` HelmRelease, Service, HTTPRoutes, and NetworkPolicy
+- `med-tracker-canary` CNPG cluster
+- `med-tracker-canary-db` and `med-tracker-canary-db-superuser`
+- `med-tracker-canary-rustfs-store`
+
+The canary CNPG cluster bootstraps from the production `med-tracker` Barman
+backup source and then uses its own secret for the application database user.
+Canary WAL archiving uses the `cnpg-med-tracker-canary` RustFS bucket.
+
+## Refresh And Promotion
+
+1. Reconcile `med-tracker-canary-db` to restore the latest production backup
+   into the isolated canary cluster.
+2. Deploy the candidate image tag to `med-tracker-canary`.
+3. Let the migration initContainer run against
+   `med-tracker-canary-rw.home.svc.cluster.local`.
+4. Smoke test `/up`, `/login`, the authenticated dashboard, and an admin path.
+5. Run baseline performance and security checks.
+6. Promote the exact image tag to production only after canary passes.
+
+The production hostname, production PVC, production Kubernetes secret, and
+`med-tracker-rw.home.svc.cluster.local` must not be modified during canary
+refreshes or migration tests.

--- a/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: med-tracker-canary-secret
+  namespace: home
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: med-tracker-canary-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      mergePolicy: Merge
+      data:
+        DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+          }}@med-tracker-canary-rw.home.svc.cluster.local:5432/med-tracker"
+        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+          }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
+          duction_cache"
+        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+          }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
+          duction_queue"
+        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+          }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
+          duction_cable"
+        OIDC_CLIENT_ID: "{{ .client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+        SMTP_ADDRESS: "smtp.resend.com"
+        SMTP_USER_NAME: "resend"
+        SMTP_PASSWORD: "{{ .RESEND_API_KEY }}"
+        MAILER_FROM: "MedTracker Canary <notifications+canary@damacus.io>"
+  dataFrom:
+    - extract:
+        key: med-tracker-canary
+    - extract:
+        key: zitadel-med-tracker-canary-oidc
+  data:
+    - secretKey: db_password
+      remoteRef:
+        key: med-tracker-canary-db
+        property: password

--- a/kubernetes/apps/home/med-tracker-canary/app/grafana-dashboard.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/grafana-dashboard.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: med-tracker-canary-logs-dashboard
+  namespace: home
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: Home
+data:
+  med-tracker-canary-logs.json: |
+    {
+      "id": null,
+      "uid": "med-tracker-canary-logs",
+      "title": "Med Tracker Canary Logs",
+      "tags": ["med-tracker-canary", "logs"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "10s",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "id": 1,
+          "title": "Parsed Application Logs",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "targets": [
+            {
+              "refId": "A",
+              "expr": "{namespace=\"home\", app=\"med-tracker-canary\"} | json level=\"log.level\", path=\"url.path\", method=\"http.request.method\", status=\"http.response.status_code\" | line_format `{{.message}} {{if .method}}{{.method}} {{end}}{{if .path}}{{.path}}{{end}}{{if .status}}status={{.status}} {{end}}{{if .level}}level={{.level}}{{end}}`",
+              "queryType": "range"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": true,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          }
+        },
+        {
+          "id": 2,
+          "title": "Raw Stream",
+          "type": "logs",
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 14
+          },
+          "targets": [
+            {
+              "refId": "B",
+              "expr": "{namespace=\"home\", app=\"med-tracker-canary\"}",
+              "queryType": "range"
+            }
+          ],
+          "options": {
+            "showTime": true,
+            "showLabels": true,
+            "showCommonLabels": false,
+            "wrapLogMessage": true,
+            "prettifyLogMessage": true,
+            "enableLogDetails": true,
+            "sortOrder": "Descending"
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/home/med-tracker-canary/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/helmrelease.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: med-tracker-canary
+  namespace: home
+spec:
+  interval: 15m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.1
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      imagePullSecrets:
+        - name: ghcr-credentials
+
+    controllers:
+      med-tracker-canary:
+        type: deployment
+        strategy: Recreate
+        # TODO: Needs a RWX PVC
+        # replicas: 2
+        # rollingUpdate:
+        #   maxSurge: 1
+        #   maxUnavailable: 0
+
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          migrate:
+            image:
+              repository: &repository ghcr.io/damacus/med-tracker
+              tag: &tag sha-8661aa8d76d86a7f37f42f9f16515bf10cf9b692
+            command: ["bin/rails", "db:prepare"]
+            envFrom:
+              - secretRef:
+                  name: med-tracker-canary-secret
+            env:
+              DATABASE_ROLE: med_tracker_owner
+              OTEL_TRACES_EXPORTER: none
+              RAILS_ENV: production
+              TZ: "Europe/London"
+        containers:
+          app:
+            image:
+              repository: *repository
+              tag: *tag
+
+            envFrom:
+              - secretRef:
+                  name: med-tracker-canary-secret
+            env:
+              RAILS_ENV: production
+              RAILS_FORCE_SSL: "false"
+              RAILS_LOG_LEVEL: info
+              OTEL_TRACES_EXPORTER: none
+              SMTP_ENABLED: "false"
+              PUSH_NOTIFICATIONS_ENABLED: "false"
+              SOLID_QUEUE_IN_PUMA: "true"
+              TZ: "Europe/London"
+              APP_URL: "https://med-tracker-canary.damacus.io"
+              OIDC_ISSUER_URL: "https://zitadel.damacus.io"
+              OIDC_REDIRECT_URI: "https://med-tracker-canary.damacus.io/auth/oidc/callback"
+              OIDC_PROVIDER_NAME: "Zitadel"
+
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /up
+                    port: &port 80
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /up
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /up
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+    route:
+      app:
+        parentRefs:
+          - name: traefik-internal
+            namespace: network
+            sectionName: websecure
+        hostnames:
+          - "med-tracker-canary.ironstone.casa"
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - kind: Service
+                name: med-tracker-canary
+                namespace: home
+                port: 80
+                weight: 1
+      external:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "traefik-ext.damacus.io"
+        parentRefs:
+          - name: traefik-internal
+            namespace: network
+            sectionName: websecure
+        hostnames:
+          - "med-tracker-canary.damacus.io"
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /up
+            backendRefs:
+              - kind: Service
+                name: med-tracker-canary
+                namespace: home
+                port: 80
+                weight: 1
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /login
+            backendRefs:
+              - kind: Service
+                name: med-tracker-canary
+                namespace: home
+                port: 80
+                weight: 1
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: ExtensionRef
+                extensionRef:
+                  group: traefik.io
+                  kind: Middleware
+                  name: oauth2-proxy-damacus-forward-auth
+            backendRefs:
+              - kind: Service
+                name: med-tracker-canary
+                namespace: home
+                port: 80
+                weight: 1
+
+    service:
+      app:
+        controller: med-tracker-canary
+        ports:
+          http:
+            port: 80
+
+    persistence:
+      storage:
+        existingClaim: med-tracker-canary-storage
+        globalMounts:
+          - path: /app/storage

--- a/kubernetes/apps/home/med-tracker-canary/app/kustomization.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - helmrelease.yaml
+  - externalsecret.yaml
+  - grafana-dashboard.yaml
+  - networkpolicy.yaml
+  - storage-pvc.yaml

--- a/kubernetes/apps/home/med-tracker-canary/app/networkpolicy.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/networkpolicy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: med-tracker-canary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/controller: med-tracker-canary
+      app.kubernetes.io/instance: med-tracker-canary
+      app.kubernetes.io/name: med-tracker-canary
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: traefik
+      ports:
+        - port: 80
+          protocol: TCP

--- a/kubernetes/apps/home/med-tracker-canary/app/storage-pvc.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/storage-pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: med-tracker-canary-storage
+  namespace: home
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/home/med-tracker-canary/ks.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app med-tracker-canary
+  namespace: flux-system
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: med-tracker-canary-db
+  path: ./kubernetes/apps/home/med-tracker-canary/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/resources/config.yaml
@@ -25,6 +25,22 @@ endpoints:
     conditions:
       - "[DNS_RCODE] == NOERROR"
 
+  - name: Med Tracker Canary Up
+    group: med-tracker-canary
+    url: https://med-tracker-canary.damacus.io/up
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+      - "[RESPONSE_TIME] < 5000"
+
+  - name: Med Tracker Canary Login
+    group: med-tracker-canary
+    url: https://med-tracker-canary.damacus.io/login
+    interval: 5m
+    conditions:
+      - "[STATUS] < 400"
+      - "[RESPONSE_TIME] < 5000"
+
 external-endpoints:
   - name: Alertmanager Watchdog
     group: cluster

--- a/kubernetes/apps/storage/rustfs/app/externalsecret.yaml
+++ b/kubernetes/apps/storage/rustfs/app/externalsecret.yaml
@@ -85,6 +85,8 @@ spec:
         RUSTFS_CNPG_MEALIE_SECRET_KEY: "{{ .rustfs_cnpg_mealie_password }}"
         RUSTFS_CNPG_MED_TRACKER_ACCESS_KEY: "{{ .rustfs_cnpg_med_tracker_username }}"
         RUSTFS_CNPG_MED_TRACKER_SECRET_KEY: "{{ .rustfs_cnpg_med_tracker_password }}"
+        RUSTFS_CNPG_MED_TRACKER_CANARY_ACCESS_KEY: "{{ .rustfs_cnpg_med_tracker_canary_username }}"
+        RUSTFS_CNPG_MED_TRACKER_CANARY_SECRET_KEY: "{{ .rustfs_cnpg_med_tracker_canary_password }}"
         RUSTFS_CNPG_PENPOT_ACCESS_KEY: "{{ .rustfs_cnpg_penpot_username }}"
         RUSTFS_CNPG_PENPOT_SECRET_KEY: "{{ .rustfs_cnpg_penpot_password }}"
         RUSTFS_LONGHORN_ACCESS_KEY: "{{ .rustfs_longhorn_username }}"
@@ -149,6 +151,14 @@ spec:
     - secretKey: rustfs_cnpg_med_tracker_password
       remoteRef:
         key: rustfs-cnpg-med-tracker
+        property: password
+    - secretKey: rustfs_cnpg_med_tracker_canary_username
+      remoteRef:
+        key: rustfs-cnpg-med-tracker-canary
+        property: username
+    - secretKey: rustfs_cnpg_med_tracker_canary_password
+      remoteRef:
+        key: rustfs-cnpg-med-tracker-canary
         property: password
     - secretKey: rustfs_cnpg_penpot_username
       remoteRef:

--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -226,6 +226,7 @@ spec:
               provision_single_bucket_identity "rustfs-cnpg-immich" "$RUSTFS_CNPG_IMMICH_ACCESS_KEY" "$RUSTFS_CNPG_IMMICH_SECRET_KEY" "cnpg-immich"
               provision_single_bucket_identity "rustfs-cnpg-mealie" "$RUSTFS_CNPG_MEALIE_ACCESS_KEY" "$RUSTFS_CNPG_MEALIE_SECRET_KEY" "cnpg-mealie"
               provision_single_bucket_identity "rustfs-cnpg-med-tracker" "$RUSTFS_CNPG_MED_TRACKER_ACCESS_KEY" "$RUSTFS_CNPG_MED_TRACKER_SECRET_KEY" "cnpg-med-tracker"
+              provision_single_bucket_identity "rustfs-cnpg-med-tracker-canary" "$RUSTFS_CNPG_MED_TRACKER_CANARY_ACCESS_KEY" "$RUSTFS_CNPG_MED_TRACKER_CANARY_SECRET_KEY" "cnpg-med-tracker-canary"
               provision_single_bucket_identity "rustfs-cnpg-penpot" "$RUSTFS_CNPG_PENPOT_ACCESS_KEY" "$RUSTFS_CNPG_PENPOT_SECRET_KEY" "cnpg-penpot"
               provision_single_bucket_identity "rustfs-longhorn" "$RUSTFS_LONGHORN_ACCESS_KEY" "$RUSTFS_LONGHORN_SECRET_KEY" "longhorn"
               provision_single_bucket_identity "rustfs-paperless" "$RUSTFS_PAPERLESS_ACCESS_KEY" "$RUSTFS_PAPERLESS_SECRET_KEY" "volsync-paperless"


### PR DESCRIPTION
## Summary

- add isolated `med-tracker-canary` app lane with its own HelmRelease, ExternalSecret, NetworkPolicy, PVC, Grafana dashboard, and Flux Kustomization
- add separate `med-tracker-canary` CNPG cluster that restores from production Barman backups but writes to canary DB secrets and canary RustFS archive storage
- expose `med-tracker-canary.damacus.io` with oauth2-proxy protection on the main route and Gatus smoke checks for `/up` and `/login`

## Safety Notes

- canary app DB URLs point at `med-tracker-canary-rw.home.svc.cluster.local`
- canary app does not reuse `med-tracker-secret` or `med-tracker-storage`
- canary DB uses `med-tracker-canary-db` and `med-tracker-canary-rustfs-store`
- production `med-tracker.damacus.io` route is unchanged

## Validation

- `mise trust`
- `task kubernetes:med-tracker-canary-isolation`
- `kustomize build kubernetes/apps/home/med-tracker-canary/app`
- `kustomize build kubernetes/apps/home/med-tracker-canary-db/app`
- `kustomize build kubernetes/apps/home`
- `kustomize build kubernetes/apps/storage/rustfs/app`
- `kustomize build kubernetes/apps/monitoring/gatus/app`
- `git diff --cached --check`
- `task kubernetes:yayamlls` exited 0, but flate printed stale mirror diagnostics that did not see the local branch paths; direct kustomize renders and `git ls-tree HEAD` confirm the paths exist.
