### PR TITLE
fix: repair gatus heartbeat wiring

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/externalsecret.yaml
@@ -73,7 +73,7 @@ spec:
             - name: heartbeat
               webhook_configs:
                 - send_resolved: false
-                  url: "http://gatus.monitoring.svc.cluster.local:8080/api/v1/endpoints/cluster_alertmanager-watchdog/external?success=true"
+                  url: "http://gatus-gatus-sidecar.monitoring.svc.cluster.local:8080/api/v1/endpoints/cluster_alertmanager-watchdog/external?success=true"
                   http_config:
                     authorization:
                       credentials: "{{ .GATUS_WATCHDOG_TOKEN }}"


### PR DESCRIPTION
## Summary
- Point Alertmanager Watchdog heartbeat at the live gatus-gatus-sidecar service.
- Removed the stale live VMServiceScrape/gatus orphan after confirming current Helm inventory only owns gatus-gatus-sidecar resources.

## Verification
- task kubernetes:yayamlls
- kustomize build kubernetes/apps/monitoring/gatus/app --load-restrictor=LoadRestrictionsNone
- kustomize build kubernetes/apps/monitoring/victoria-metrics/app --load-restrictor=LoadRestrictionsNone
- task kubernetes:alerts (ScrapePoolHasNoTargets absent)
- task kubernetes:edge-smoke