### PR TITLE
fix(gatus): auto-discover httproutes

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
           prefix: ""
         httproute:
           enable: true
-          auto: false
+          auto: true
           prefix: ""
         service:
           enable: false


### PR DESCRIPTION
## Summary
- enable HTTPRoute auto-discovery for the existing Gatus sidecar
- keep discovery scoped to the traefik-internal gateway and preserve explicit route opt-outs

## Validation
- task flux:flate-test
- task kubernetes:yayamlls

Live rollout and endpoint-count verification need the PR merged first because main is protected.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3813" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->