### PR TITLE
fix(gatus): wait for sidecar config

### DIFF
--- a/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/gatus/app/helmrelease.yaml
@@ -25,6 +25,7 @@ spec:
     gatus:
       image:
         tag: v5.36.0
+      delayStartSeconds: "5"
       env:
         TZ: Europe/London
       extraEnv:


### PR DESCRIPTION
## Summary
- add a short Gatus startup delay so the generated sidecar config exists before Gatus loads configuration
- fixes the observed race after enabling HTTPRoute auto-discovery, where Gatus started with only the static config

## Validation
- task flux:flate-test
- task kubernetes:yayamlls

## Live note
After PR #3813 rolled out, the sidecar generated HTTPRoute endpoints but Gatus loaded only /config/config.yaml on one restart. The delay makes startup deterministic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3814" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->