### PR TITLE
fix(matter): migrate server to matterjs

### DIFF
--- a/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
@@ -36,28 +36,44 @@ spec:
       matter-server:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          fix-data-permissions:
+            image:
+              repository: busybox
+              tag: 1.38.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - chown -R 1000:1000 /data
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN"]
+              runAsGroup: 0
+              runAsNonRoot: false
+              runAsUser: 0
+              seccompProfile: { type: RuntimeDefault }
         pod:
           securityContext:
-            runAsUser: 0 # Must be run as root user
-            runAsGroup: 100
-            runAsNonRoot: false
-            fsGroup: 100
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
             fsGroupChangePolicy: "OnRootMismatch"
-            supplementalGroups: [34]
 
         containers:
           app:
             image:
-              repository: ghcr.io/home-assistant-libs/python-matter-server
-              tag: 8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+              repository: ghcr.io/matter-js/matterjs-server
+              tag: 1.1.7@sha256:e52dc38320b53a0611628a8c3ed416a0dbb47c98ff83c9ef815f4184373f27b5
               pullPolicy: IfNotPresent
             env:
               TZ: "Europe/London"
-              MATTER_SERVER__INSTANCE_NAME: Matter-Server
-              MATTER_SERVER__PORT: &port 5580
-              MATTER_SERVER__APPLICATION_URL: "matter.ironstone.casa"
-              MATTER_SERVER__LOG_LEVEL: info
-              MATTER_SERVER__VENDOR_ID: 4939
+              PORT: "5580"
+              STORAGE_PATH: /data
+              LOG_LEVEL: info
+              PRODUCTION_MODE: "true"
+              NODE_OPTIONS: "--max-old-space-size=512"
             probes:
               liveness:
                 enabled: true
@@ -70,15 +86,19 @@ spec:
                   periodSeconds: 5
             resources:
               requests:
-                memory: "120M"
+                memory: "128Mi"
                 cpu: "100m"
               limits:
-                memory: "500M"
+                memory: "768Mi"
                 cpu: "1000m"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
 
     # Matter discovers devices using MDNS and neighbors discovery,
     # thus we need the controller to be on the host network.
-    # https://github.com/home-assistant-libs/python-matter-server?tab=readme-ov-file#requirements-to-communicate-with-thread-devices-through-thread-border-routers
+    # https://github.com/matter-js/matterjs-server/blob/main/docs/docker.md
     defaultPodOptions:
       imagePullSecrets:
         - name: ghcr-credentials
@@ -97,7 +117,7 @@ spec:
             enabled: true
             primary: true
             protocol: TCP
-            port: *port
+            port: &port 5580
           mdns-tcp:
             enabled: true
             port: 5353


### PR DESCRIPTION
## Summary
- replace the archived Python Matter Server image with matter-js/matterjs-server 1.1.7
- switch to Matter.js environment variables and run the container as UID/GID 1000
- add a one-time data permission init container and set a 512 MiB Node heap under a 768 MiB memory limit

## Verification
- task kubernetes:yayamlls
- live HelmRelease reconciled as home-automation/matter-server.v19
- Matter.js pod ready with zero restarts
- HTTP check on http://192.168.1.234:5580 returned 200
- post-migration log scan found no ERROR/CRITICAL/FATAL/Exception matches
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3818" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->