### PR TITLE
fix(matter): lower matterjs memory limit

### DIFF
--- a/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/matter/app/helmrelease.yaml
@@ -73,7 +73,7 @@ spec:
               STORAGE_PATH: /data
               LOG_LEVEL: info
               PRODUCTION_MODE: "true"
-              NODE_OPTIONS: "--max-old-space-size=512"
+              NODE_OPTIONS: "--max-old-space-size=384"
             probes:
               liveness:
                 enabled: true
@@ -86,10 +86,10 @@ spec:
                   periodSeconds: 5
             resources:
               requests:
-                memory: "128Mi"
+                memory: "256Mi"
                 cpu: "100m"
               limits:
-                memory: "768Mi"
+                memory: "512Mi"
                 cpu: "1000m"
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
- reduce Matter.js server memory request/limit to 256Mi/512Mi
- lower V8 old-space cap to 384Mi so Node has headroom inside the 512Mi container

## Validation
- yq assertion for NODE_OPTIONS and memory request/limit
- kubectl kustomize kubernetes/apps/home-automation/matter/app
- task kubernetes:yayamlls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3819" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->