### PR TITLE
fix(konflate): roll back oom-prone release

### DIFF
--- a/kubernetes/apps/dev/konflate/app/oci-repository.yaml
+++ b/kubernetes/apps/dev/konflate/app/oci-repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.3.0
+    tag: 0.2.34
   url: oci://ghcr.io/home-operations/charts/konflate


### PR DESCRIPTION
## Summary
- roll Konflate chart back from 0.3.0 to 0.2.34
- 0.3.0 rollout correlates with the live pod's 57 OOMKilled restarts
- avoid masking the regression with a memory limit increase

## Verification
- task flux:flate-test
- live metrics showed only the 0.3.0 Konflate pod restarting/OOMKilled
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3831" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->