### PR TITLE
fix(k3s): cap kubelet pod log rotation

### DIFF
--- a/ansible/inventory/group_vars/controllers/main.yaml
+++ b/ansible/inventory/group_vars/controllers/main.yaml
@@ -23,6 +23,8 @@ k3s_server:
   kube-scheduler-arg:
     - "bind-address=0.0.0.0"
   kubelet-arg:
+    - "container-log-max-files=2"
+    - "container-log-max-size=1Mi"
     - "image-gc-high-threshold=55"
     - "image-gc-low-threshold=50"
   node-ip: "{{ ansible_host }}"

--- a/provisioning/armbian-build/userpatches/overlay/etc/rancher/k3s/config.yaml.template
+++ b/provisioning/armbian-build/userpatches/overlay/etc/rancher/k3s/config.yaml.template
@@ -46,5 +46,7 @@ kube-scheduler-arg:
   - bind-address=0.0.0.0
 
 kubelet-arg:
+  - container-log-max-files=2
+  - container-log-max-size=1Mi
   - image-gc-high-threshold=55
   - image-gc-low-threshold=50


### PR DESCRIPTION
## Summary
- cap kubelet container log rotation at 2 files x 1Mi per container
- apply the setting to both Ansible-managed controller config and the baked Armbian image template
- reduce risk of pod logs filling the 50MiB Armbian /var/log ramlog tmpfs

## Live remediation
- removed stale rotated KEDA and Longhorn pod logs from node-0b0715
- /var/log on node-0b0715 recovered from 99-100% full to about 61% full
- NodeFilesystemSpaceFillingUp and NodeFilesystemAlmostOutOfSpace are no longer active in task kubernetes:alerts

## Verification
- yq e '.k3s_server."kubelet-arg"' ansible/inventory/group_vars/controllers/main.yaml
- yq e '."kubelet-arg"' provisioning/armbian-build/userpatches/overlay/etc/rancher/k3s/config.yaml.template
- git diff --check
- task kubernetes:alerts

## Follow-up
The committed kubelet args take effect when the managed K3s config is applied and K3s/kubelet restarts on nodes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->