### PR TITLE
fix(monitoring): disable unscraped k3s rule groups

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -109,6 +109,17 @@ spec:
         # Use the existing Alertmanager configuration secret from KPS/ExternalSecret
         configSecret: alertmanager-secret
 
+    # k3s does not expose these static control-plane components as scrape targets.
+    # Keep the default rule sync aligned with the disabled scrape components below.
+    defaultRules:
+      groups:
+        kube-scheduler.rules:
+          enabled: false
+        kubernetes-system-controller-manager:
+          enabled: false
+        kubernetes-system-scheduler:
+          enabled: false
+
     # Disable components we don't need or are duplicated
     grafana:
       enabled: false


### PR DESCRIPTION
## Summary
- disable default VictoriaMetrics rule groups for kube-scheduler and kube-controller-manager
- keep generated rules aligned with disabled k3s component scrapes
- stop false KubeSchedulerDown, KubeControllerManagerDown, and scheduler RecordingRulesNoData alerts

## Root cause
The chart values already disable kubeScheduler and kubeControllerManager scraping because k3s does not expose those static control-plane components through matching scrape targets. The sync-job still generated VMRules for those groups, so vmalert fired on absent kube-scheduler/kube-controller-manager targets and missing scheduler recording-rule samples.

## Verification
- yq e '.spec.values.defaultRules.groups' kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
- git diff --check
- task kubernetes:yayamlls
- task flux:flate-build

Note: app-scoped flate builds were intentionally not valid because they omit required Flux dependencies; the full repository flate build passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3835" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->