### PR TITLE
fix(rustfs): decouple bootstrap from legacy mirroring

### DIFF
--- a/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
+++ b/kubernetes/apps/storage/rustfs/app/job-buckets.yaml
@@ -2,17 +2,17 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: rustfs-iam-bootstrap-v4
+  name: rustfs-iam-bootstrap-v5
   namespace: storage
   annotations:
     kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
-  backoffLimit: 6
-  ttlSecondsAfterFinished: 3600
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 86400
   template:
     spec:
       automountServiceAccountToken: false
-      restartPolicy: OnFailure
+      restartPolicy: Never
       securityContext:
         runAsNonRoot: true
         runAsUser: 10001
@@ -158,18 +158,6 @@ spec:
                 rc admin policy create rustfs "$policy_name" "$policy_file" || true
               }
 
-              mirror_prefix_if_present() {
-                source_path="$1"
-                destination_bucket="$2"
-
-                if rc object list "rustfs/$source_path" >/dev/null 2>&1; then
-                  echo "Mirroring existing data from $source_path to $destination_bucket"
-                  rc mirror --overwrite "rustfs/$source_path" "rustfs/$destination_bucket"
-                else
-                  echo "No existing data found at $source_path; skipping mirror"
-                fi
-              }
-
               ensure_user() {
                 identity="$1"
                 access_key="$2"
@@ -230,16 +218,6 @@ spec:
               provision_single_bucket_identity "rustfs-longhorn" "$RUSTFS_LONGHORN_ACCESS_KEY" "$RUSTFS_LONGHORN_SECRET_KEY" "longhorn"
               provision_single_bucket_identity "rustfs-paperless" "$RUSTFS_PAPERLESS_ACCESS_KEY" "$RUSTFS_PAPERLESS_SECRET_KEY" "volsync-paperless"
               provision_loki_identity
-
-              mirror_prefix_if_present "cnpg-backups/zitadel" "cnpg-zitadel"
-              mirror_prefix_if_present "cnpg-backups/forgejo" "cnpg-forgejo"
-              mirror_prefix_if_present "cnpg-backups/home-assistant" "cnpg-home-assistant"
-              mirror_prefix_if_present "cnpg-backups/n8n" "cnpg-n8n"
-              mirror_prefix_if_present "cnpg-backups/immich" "cnpg-immich"
-              mirror_prefix_if_present "cnpg-backups/mealie" "cnpg-mealie"
-              mirror_prefix_if_present "cnpg-backups/med-tracker" "cnpg-med-tracker"
-              mirror_prefix_if_present "cnpg-backups/penpot" "cnpg-penpot"
-              mirror_prefix_if_present "volsync-backups/paperless" "volsync-paperless"
       volumes:
         - name: tmp
           emptyDir: {}

--- a/tests/mondoo/rustfs-iam.mql.yaml
+++ b/tests/mondoo/rustfs-iam.mql.yaml
@@ -169,19 +169,20 @@ policies:
               file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("longhorn")
               file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("loki-chunks")
               file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("loki-data")
-          - uid: rustfs-bootstrap-preserves-old-prefix-mirroring
-            title: RustFS bootstrap keeps old-prefix mirror jobs for safe migration
+          - uid: rustfs-bootstrap-does-not-run-legacy-mirroring
+            title: RustFS bootstrap does not run legacy-prefix mirrors
             impact: 100
             mql: |
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/zitadel")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/forgejo")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/home-assistant")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/n8n")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/immich")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/mealie")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/med-tracker")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/penpot")
-              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("volsync-backups/paperless")
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("mirror_prefix_if_present") == false
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("rc mirror") == false
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("cnpg-backups/") == false
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("volsync-backups/paperless") == false
+          - uid: rustfs-bootstrap-retains-failed-pods
+            title: RustFS bootstrap keeps failed pod logs available for debugging
+            impact: 100
+            mql: |
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("ttlSecondsAfterFinished: 86400")
+              file("kubernetes/apps/storage/rustfs/app/job-buckets.yaml").content.contains("restartPolicy: Never")
           - uid: rustfs-bootstrap-creates-app-identities
             title: RustFS bootstrap job creates all app IAM identities
             impact: 100


### PR DESCRIPTION
## Summary
- remove legacy prefix mirroring from the RustFS IAM bootstrap job
- bump the Job name to v5 so Flux creates a fresh IAM-only run
- retain failed job artifacts longer and use restartPolicy: Never for inspectable failures
- update the RustFS Mondoo policy to assert bootstrap stays IAM-only

## Verification
- task kubernetes:rustfs-iam-policy
- yq -e '.metadata.name == "rustfs-iam-bootstrap-v5" and .spec.ttlSecondsAfterFinished == 86400 and .spec.backoffLimit == 1 and .spec.template.spec.restartPolicy == "Never"' kubernetes/apps/storage/rustfs/app/job-buckets.yaml
- task flux:flate-test path=./kubernetes (RustFS passed; unrelated Docker Hub 500 resolving Bitnami Redis caused the only failure)
- live: kubectl apply -f kubernetes/apps/storage/rustfs/app/job-buckets.yaml
- live: kubectl wait -n storage --for=condition=complete job/rustfs-iam-bootstrap-v5 --timeout=5m
- live: task kubernetes:alerts now shows no RustFS KubeJobFailed alert