### PR TITLE
fix(monitoring): match node thermal metric labels

### DIFF
--- a/kubernetes/apps/monitoring/victoria-metrics/app/prometheusrule.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/prometheusrule.yaml
@@ -117,18 +117,18 @@ spec:
         - alert: NodeHighCpuTemperature
           annotations:
             summary: "High CPU temperature on {{ $labels.instance }}"
-            description: "CPU thermal zone {{ $labels.chip_name }} on {{ $labels.instance }} is at {{ $value | printf \"%.1f\" }}°C (threshold: 75°C)"
+            description: "CPU thermal zone {{ $labels.chip }} on {{ $labels.instance }} is at {{ $value | printf \"%.1f\" }}°C (threshold: 75°C)"
           expr: |
-            node_hwmon_temp_celsius{chip_name=~".*_thermal"} > 75
+            node_hwmon_temp_celsius{chip=~"thermal.*"} > 75
           for: 5m
           labels:
             severity: warning
         - alert: NodeCriticalCpuTemperature
           annotations:
             summary: "Critical CPU temperature on {{ $labels.instance }}"
-            description: "CPU thermal zone {{ $labels.chip_name }} on {{ $labels.instance }} is at {{ $value | printf \"%.1f\" }}°C, approaching critical threshold"
+            description: "CPU thermal zone {{ $labels.chip }} on {{ $labels.instance }} is at {{ $value | printf \"%.1f\" }}°C, approaching critical threshold"
           expr: |
-            node_hwmon_temp_celsius{chip_name=~".*_thermal"} > 90
+            node_hwmon_temp_celsius{chip=~"thermal.*"} > 90
           for: 2m
           labels:
             severity: critical
@@ -144,7 +144,7 @@ spec:
         - alert: NodeTemperatureNearCritical
           annotations:
             summary: "Temperature approaching critical on {{ $labels.instance }}"
-            description: "{{ $labels.chip_name }} on {{ $labels.instance }} is at {{ $value | printf \"%.0f\" }}% of critical threshold"
+            description: "{{ $labels.chip }} on {{ $labels.instance }} is at {{ $value | printf \"%.0f\" }}% of critical threshold"
           expr: |
             (node_hwmon_temp_celsius / on(chip, instance, sensor) node_hwmon_temp_crit_celsius) * 100 > 80
           for: 5m


### PR DESCRIPTION
## Summary
- update node CPU thermal alerts to select live `node_hwmon_temp_celsius` series by `chip` instead of absent `chip_name`
- update alert annotations to print the live `chip` label
- keep NVMe and near-critical join behavior unchanged apart from annotation label text

## Live findings
- `node_hwmon_temp_celsius{chip_name=~".*_thermal"}` returned 0 series
- `node_hwmon_temp_celsius{chip=~"thermal.*"}` returned 42 series
- live vmalert now shows `NodeHighCpuTemperature` and `NodeCriticalCpuTemperature` using `chip=~"thermal.*"`

## Last 30 minutes
- hottest CPU thermal: node `192.168.1.186:9100`, max 75.769C
- hottest NVMe: node `192.168.1.186:9100`, max 68.85C
- Home Assistant loft sensor `sensor.loft_motion_sensor_temperature`: min 43.2C, avg 43.4C, max 43.5C; latest 43.4C at 2026-07-09T15:04:59Z

## Verification
- yq assertions for NodeHighCpuTemperature and NodeCriticalCpuTemperature selectors
- kubectl apply -n monitoring -f kubernetes/apps/monitoring/victoria-metrics/app/prometheusrule.yaml
- vmalert /api/v1/rules shows corrected queries
- task flux:flate-test path=./kubernetes
