### PR TITLE
fix: lower wyoming cpu requests

### DIFF
--- a/kubernetes/apps/home-automation/piper/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/piper/app/HelmRelease.yaml
@@ -53,7 +53,7 @@ spec:
 
             resources:
               requests:
-                cpu: 250m
+                cpu: 10m
                 memory: 1Gi
               limits:
                 cpu: 2000m

--- a/kubernetes/apps/home-automation/wakeword/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/wakeword/app/HelmRelease.yaml
@@ -48,7 +48,7 @@ spec:
 
             resources:
               requests:
-                cpu: 250m
+                cpu: 10m
                 memory: 1Gi
               limits:
                 cpu: 2000m

--- a/kubernetes/apps/home-automation/whisper/app/HelmRelease.yaml
+++ b/kubernetes/apps/home-automation/whisper/app/HelmRelease.yaml
@@ -53,7 +53,7 @@ spec:
 
             resources:
               requests:
-                cpu: 500m
+                cpu: 25m
                 memory: 2Gi
               limits:
                 cpu: 4000m


### PR DESCRIPTION
## Summary

Lower the CPU requests for the Wyoming voice services so they no longer consume nearly a full core of scheduler capacity while sitting mostly idle.

This keeps the existing CPU limits in place, so whisper, piper, and openwakeword can still burst when they need to process audio. The practical outcome is less requested CPU pressure on the cluster and more room for the N-1 overcommit alert to clear.

## Verification

- task kubernetes:yayamlls
- pre-commit hooks during commit
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->