### PR TITLE
fix: automerge cert-manager updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,7 @@
         "ghcr.io/paperless-ngx/paperless-ngx",
         "registry.k8s.io/kubectl",
         "ghcr.io/zitadel/zitadel",
+        "quay.io/jetstack/charts/cert-manager",
         "external-secrets",
         "victoria-metrics-k8s-stack",
         "zitadel",


### PR DESCRIPTION
## Summary

Configure Renovate to auto-merge non-major cert-manager chart updates, including routine security releases.

## Verification

- npx --yes json5 .github/renovate.json5
- task kubernetes:yayamlls
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3861" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->