### PR TITLE
chore(med-tracker): update to 0.5.11

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.10
+              tag: &tag 0.5.11
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary

- Updates the MedTracker deployment and migration init container from `0.5.10` to `0.5.11`.
- Deploys the retry-safe portable ID migration fix for the production rollout failure tracked in damacus/med-tracker#1677.
- The recovered `0.5.11` registry image was verified for linux/amd64 and linux/arm64, including its baked immutable runtime reference.

Rendered Kubernetes manifests validate successfully with the repository task.