### PR TITLE
fix(med-tracker): provision audit database roles

### DIFF
--- a/kubernetes/apps/home/med-tracker-db/app/cluster.yaml
+++ b/kubernetes/apps/home/med-tracker-db/app/cluster.yaml
@@ -14,6 +14,18 @@ spec:
     major: 18
   instances: 2
   primaryUpdateStrategy: unsupervised
+  managed:
+    roles:
+      - name: med_tracker_audit_exporter
+        ensure: present
+        login: false
+        superuser: false
+        bypassrls: false
+      - name: med_tracker_audit_verifier
+        ensure: present
+        login: false
+        superuser: false
+        bypassrls: false
   storage:
     size: 5Gi
     storageClass: openebs-hostpath


### PR DESCRIPTION
## Summary

The `0.5.11` rollout reached the migration init container but failed closed because production did not contain the two non-login audit roles required by the new audit migrations.

This declares both `med_tracker_audit_exporter` and `med_tracker_audit_verifier` as CloudNativePG-managed roles. Each role is explicitly present, cannot log in, is not a superuser, and cannot bypass row-level security.

Provisioning both roles avoids fixing the exporter migration only to fail immediately on the following verifier migration.