### PR TITLE
fix(med-tracker): deploy 0.5.12

### DIFF
--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.11
+              tag: &tag 0.5.12
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:


### PR DESCRIPTION
The 0.5.11 rollout reaches the database migration but fails because forced row-level security hides valid carer relationship endpoints from the migration owner.\n\nMedTracker 0.5.12 temporarily relaxes that forced policy only for the validated backfill and restores it even on failure. This updates the deployment to the published multi-architecture patch image so the upgrade can complete.