### PR TITLE
fix: set CNPG backup alert to 30h

### DIFF
--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -130,21 +130,9 @@ spec:
                         uid: prometheus
                       editorMode: code
                       expr: |-
-                        (
-                          min by (namespace, job) (
-                            time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{
-                              job!~"dev/forgejo-green|home-automation/(home-assistant-green|n8n-green)"
-                            }
-                          ) > 10800
-                        )
-                        or
-                        (
-                          min by (namespace, job) (
-                            time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp{
-                              job=~"dev/forgejo-green|home-automation/(home-assistant-green|n8n-green)"
-                            }
-                          ) > 129600
-                        )
+                        min by (namespace, job) (
+                          time() - barman_cloud_cloudnative_pg_io_last_available_backup_timestamp
+                        ) > 108000
                       instant: true
                       intervalMs: 1000
                       maxDataPoints: 43200
@@ -192,7 +180,7 @@ spec:
                 execErrState: Alerting
                 for: 15m
                 annotations:
-                  summary: CNPG backup age exceeds expected schedule
+                  summary: CNPG backup age exceeds 30 hours
                   description: A CNPG cluster has no recent successful Barman backup for its schedule.
                 labels:
                   severity: critical


### PR DESCRIPTION
## Summary

- Replace mixed 3-hour/36-hour CNPG stale-backup thresholds with one 30-hour threshold (108000 seconds).
- Remove hard-coded cluster exceptions.
- Update the alert summary to state that backup age exceeds 30 hours.

## Verification

- task kubernetes:yayamlls passed.
- git diff --cached --check passed before commit.
- Pre-commit checks passed, including yamllint and Kubernetes secret checks.
- Confirmed the rule contains 108000 and no longer contains 10800, 129600, or the old exception selectors.

## Risks / follow-ups

- Flux reconciliation is required before the live Grafana rule changes.
- The separate recent-backup-failure alert remains unchanged.