### PR TITLE
fix(med-tracker): disable automatic updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,10 +25,14 @@
       automerge: true,
     },
     {
+      description: "Disable all MedTracker updates",
+      matchPackageNames: ["ghcr.io/damacus/med-tracker"],
+      enabled: false,
+    },
+    {
       description: "Auto-merge non-major updates for selected home-ops assets",
       matchPackageNames: [
         "ghcr.io/coder/code-server",
-        "ghcr.io/damacus/med-tracker",
         "ghcr.io/home-operations/home-assistant",
         "ghcr.io/mealie-recipes/mealie",
         "ghcr.io/paperless-ngx/paperless-ngx",

--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -186,8 +186,10 @@ tasks:
       - { msg: "Missing RustFS live IAM check script", sh: "test -f {{.RUSTFS_IAM_LIVE_CHECK_SCRIPT}}" }
 
   med-tracker-canary-isolation:
-    desc: Assert Med Tracker canary uses isolated app, storage, route, and database resources
+    desc: Assert Med Tracker canary isolation and production update controls
     cmds:
+      - yq -e '[.packageRules[] | select(.matchPackageNames[] == "ghcr.io/damacus/med-tracker")] | (length == 1 and .[0].enabled == false)' {{.ROOT_DIR}}/.github/renovate.json5
+      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.image.tag == "0.5.7"' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
       - yq -e '.metadata.name == "med-tracker-canary" and .spec.values.controllers."med-tracker-canary".containers.app.env.APP_URL == "https://med-tracker-canary.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.OIDC_REDIRECT_URI == "https://med-tracker-canary.damacus.io/auth/oidc/callback"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.SMTP_ENABLED == "false" and .spec.values.controllers."med-tracker-canary".containers.app.env.PUSH_NOTIFICATIONS_ENABLED == "false"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.13
+              tag: &tag 0.5.7
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary

- Disable Renovate updates for the MedTracker container and remove it from the automatic merge list.
- Pin the standard MedTracker release back to the healthy 0.5.7 image.
- Guard the update controls and production tag with the focused MedTracker assertion task.

## Risks / follow-ups

- This changes desired GitOps state only; it does not modify live Kubernetes resources.