### PR TITLE
fix: rollback Vector to 0.56

### DIFF
--- a/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/vector/app/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: vector
-      version: 0.57.0
+      version: 0.56.0
       sourceRef:
         kind: HelmRepository
         name: vector
@@ -27,7 +27,7 @@ spec:
 
     image:
       repository: timberio/vector
-      tag: 0.57.0-debian
+      tag: 0.56.0-debian
 
     service:
       enabled: true
@@ -90,18 +90,7 @@ spec:
         filter_ingested_logs:
           type: filter
           inputs: [remap_kubernetes_logs]
-          condition: |
-            !(
-              .label.namespace == "openebs-system" &&
-              .label.app == "loki" &&
-              is_string(.message) &&
-              (
-                contains(string!(.message), "caller=index_set.go") ||
-                contains(string!(.message), "caller=table_manager.go") ||
-                contains(string!(.message), "caller=recalculate_owned_streams.go") ||
-                contains(string!(.message), "caller=flush.go")
-              )
-            )
+          condition: '.label.namespace != "openebs-system" || .label.app != "loki" || !is_string(.message) || !(contains(string!(.message), "caller=index_set.go") || contains(string!(.message), "caller=table_manager.go") || contains(string!(.message), "caller=recalculate_owned_streams.go") || contains(string!(.message), "caller=flush.go"))'
 
         home_assistant_bt_metric:
           type: log_to_metric


### PR DESCRIPTION
## Summary

- Roll back the Vector chart and image from 0.57.0 to the known-good 0.56.0 release.
- Rewrite the Loki noise filter as a parser-safe single-line VRL condition.

## Verification

- task kubernetes:yayamlls passed.
- Pre-commit validation passed, including yamllint and Kubernetes secret checks.
- Live HelmRelease reports Ready=True with Vector 0.56.0.
- All three Vector pods are 1/1 Running with zero restarts after rollout.
- The stale KubePodCrashLooping alerts for the deleted Vector pods cleared after one evaluation cycle.

## Risks / follow-ups

- A future Vector 0.57 upgrade must migrate the dynamic Loki label templates to the stricter template-resolution behavior before reattempting the upgrade.