### PR TITLE
fix(med-tracker): roll back 0.5.15

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -189,7 +189,7 @@ tasks:
     desc: Assert Med Tracker canary isolation and production update controls
     cmds:
       - yq -e '[.packageRules[] | select(.matchPackageNames[] == "ghcr.io/damacus/med-tracker")] | (length == 1 and .[0].enabled == false)' {{.ROOT_DIR}}/.github/renovate.json5
-      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.image.tag == "0.5.15"' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.image.tag == "0.5.7"' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
       - yq -e '.metadata.name == "med-tracker-canary" and .spec.values.controllers."med-tracker-canary".containers.app.env.APP_URL == "https://med-tracker-canary.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.OIDC_REDIRECT_URI == "https://med-tracker-canary.damacus.io/auth/oidc/callback"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.SMTP_ENABLED == "false" and .spec.values.controllers."med-tracker-canary".containers.app.env.PUSH_NOTIFICATIONS_ENABLED == "false"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,7 +46,7 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.15
+              tag: &tag 0.5.7
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:


### PR DESCRIPTION
Restores the production Med Tracker pin to 0.5.7 after the 0.5.15 init migration failed against the existing CNPG database.

The failing migration was AddExpiryTrackingToSupportAccessSessions: PostgreSQL rejected ALTER TABLE because the application connection is not the owner of support_access_sessions. The migration transaction was cancelled. This PR restores the last healthy image while the release is fixed for existing-database ownership compatibility.