### PR TITLE
fix(med-tracker): deploy 0.5.15 on CNPG

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -189,7 +189,8 @@ tasks:
     desc: Assert Med Tracker canary isolation and production update controls
     cmds:
       - yq -e '[.packageRules[] | select(.matchPackageNames[] == "ghcr.io/damacus/med-tracker")] | (length == 1 and .[0].enabled == false)' {{.ROOT_DIR}}/.github/renovate.json5
-      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.image.tag == "0.5.7"' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.image.tag == "0.5.15"' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker".initContainers.migrate.env | has("DATABASE_ROLE") | not' {{.KUBERNETES_DIR}}/apps/home/med-tracker/app/helmrelease.yaml
       - yq -e '.metadata.name == "med-tracker-canary" and .spec.values.controllers."med-tracker-canary".containers.app.env.APP_URL == "https://med-tracker-canary.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.OIDC_REDIRECT_URI == "https://med-tracker-canary.damacus.io/auth/oidc/callback"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.SMTP_ENABLED == "false" and .spec.values.controllers."med-tracker-canary".containers.app.env.PUSH_NOTIFICATIONS_ENABLED == "false"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -46,13 +46,12 @@ spec:
           migrate:
             image:
               repository: &repository ghcr.io/damacus/med-tracker
-              tag: &tag 0.5.7
+              tag: &tag 0.5.15
             command: ["bin/rails", "db:prepare"]
             envFrom:
               - secretRef:
                   name: med-tracker-secret
             env:
-              DATABASE_ROLE: med_tracker_owner
               OTEL_TRACES_EXPORTER: none
               RAILS_ENV: production
               TZ: "Europe/London"


### PR DESCRIPTION
Promotes production Med Tracker to 0.5.15 using the release’s existing-database contract for CloudNativePG.

The first rollout forced migrations into med_tracker_owner, which cannot alter tables still owned by the historical shared login. This keeps DATABASE_ROLE unset for db:prepare so the existing login can migrate both ownership generations, and adds a focused guard against reintroducing the incompatible setting.

Runtime credentials, Renovate controls, canary resources, CNPG configuration, and secrets are unchanged.