### PR TITLE
fix: prevent false cluster alerts

### DIFF
--- a/.taskfiles/Kubernetes/Taskfile.yaml
+++ b/.taskfiles/Kubernetes/Taskfile.yaml
@@ -79,10 +79,11 @@ tasks:
       - { msg: "Missing kubectl", sh: "command -v kubectl >/dev/null" }
 
   cnpg-backups:
-    desc: Check CNPG backup resources and WAL archiving status
+    desc: Check CNPG backup freshness, resources, and WAL archiving status
     summary: |
-      Summarizes latest Backup resources, latest successful backups, and
-      kubectl cnpg status WAL archiving health for every CNPG cluster.
+      Checks that every active CNPG cluster has a successful backup no more
+      than 30 hours old, then summarizes Backup resources and WAL archiving
+      health.
 
       Examples:
         task kubernetes:cnpg-backups
@@ -196,6 +197,7 @@ tasks:
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.env.SMTP_ENABLED == "false" and .spec.values.controllers."med-tracker-canary".containers.app.env.PUSH_NOTIFICATIONS_ENABLED == "false"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".initContainers.migrate.envFrom[0].secretRef.name == "med-tracker-canary-secret"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.controllers."med-tracker-canary".containers.app.envFrom[0].secretRef.name == "med-tracker-canary-secret"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
+      - yq -e '.spec.values.controllers."med-tracker-canary".serviceAccount.identifier == "med-tracker-canary-app" and .spec.values.serviceAccount."med-tracker-canary-app".forceRename == "med-tracker-canary-app"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.persistence.storage.existingClaim == "med-tracker-canary-storage"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.route.external.hostnames[0] == "med-tracker-canary.damacus.io" and .spec.values.route.external.annotations."external-dns.alpha.kubernetes.io/target" == "traefik-ext.damacus.io"' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml
       - yq -e '.spec.values.route.external.rules[] | select(.matches[0].path.value == "/" and .filters[0].extensionRef.name == "oauth2-proxy-damacus-forward-auth" and .backendRefs[0].name == "med-tracker-canary")' {{.MED_TRACKER_CANARY_APP}}/helmrelease.yaml

--- a/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
@@ -15,15 +15,15 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/med-tracker"
-        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_cache"
-        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_queue"
-        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_cable"
         OIDC_CLIENT_ID: "{{ .client_id }}"

--- a/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/externalsecret.yaml
@@ -15,15 +15,15 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/med-tracker"
-        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_cache"
-        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_queue"
-        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-canary-rw.home.svc.cluster.local:5432/medtracker_pro\
           duction_cable"
         OIDC_CLIENT_ID: "{{ .client_id }}"

--- a/kubernetes/apps/home/med-tracker-canary/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker-canary/app/helmrelease.yaml
@@ -34,6 +34,8 @@ spec:
       med-tracker-canary:
         type: deployment
         strategy: Recreate
+        serviceAccount:
+          identifier: med-tracker-canary-app
         # TODO: Needs a RWX PVC
         # replicas: 2
         # rollingUpdate:
@@ -200,6 +202,10 @@ spec:
         ports:
           http:
             port: 80
+
+    serviceAccount:
+      med-tracker-canary-app:
+        forceRename: med-tracker-canary-app
 
     persistence:
       storage:

--- a/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
@@ -15,15 +15,15 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-rw.home.svc.cluster.local:5432/med-tracker"
-        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_c\
           ache"
-        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_q\
           ueue"
-        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password
+        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_c\
           able"
         OIDC_CLIENT_ID: "{{ .client_id }}"

--- a/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
+++ b/kubernetes/apps/home/med-tracker/app/externalsecret.yaml
@@ -15,15 +15,15 @@ spec:
       engineVersion: v2
       mergePolicy: Merge
       data:
-        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-rw.home.svc.cluster.local:5432/med-tracker"
-        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_CACHE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_c\
           ache"
-        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_QUEUE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_q\
           ueue"
-        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery
+        SOLID_CABLE_DATABASE_URL: "postgresql://med-tracker:{{ .db_password | urlquery | replace \"+\" \"%20\"
           }}@med-tracker-rw.home.svc.cluster.local:5432/medtracker_production_c\
           able"
         OIDC_CLIENT_ID: "{{ .client_id }}"

--- a/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
+++ b/kubernetes/apps/home/med-tracker/app/helmrelease.yaml
@@ -34,6 +34,8 @@ spec:
       med-tracker:
         type: deployment
         strategy: Recreate
+        serviceAccount:
+          identifier: med-tracker-app
         # TODO: Needs a RWX PVC
         # replicas: 2
         # rollingUpdate:
@@ -171,6 +173,10 @@ spec:
         ports:
           http:
             port: 80
+
+    serviceAccount:
+      med-tracker-app:
+        forceRename: med-tracker-app
 
     persistence:
       storage:

--- a/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/grafana/app/helmrelease.yaml
@@ -176,7 +176,8 @@ spec:
                       expression: B
                       refId: C
                       type: threshold
-                noDataState: NoData
+                # No matching series means every backup is within the 30-hour limit.
+                noDataState: OK
                 execErrState: Alerting
                 for: 15m
                 annotations:

--- a/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/victoria-metrics/app/helmrelease.yaml
@@ -112,6 +112,11 @@ spec:
     # k3s does not expose these static control-plane components as scrape targets.
     # Keep the default rule sync aligned with the disabled scrape components below.
     defaultRules:
+      rules:
+        RecordingRulesNoData:
+          spec:
+            # count:up0 intentionally returns no series when every scrape target is healthy.
+            expr: sum(vmalert_recording_rules_last_evaluation_samples{recording!="count:up0"}) without(id) < 1
       groups:
         kube-scheduler.rules:
           enabled: false

--- a/scripts/cluster-health.py
+++ b/scripts/cluster-health.py
@@ -22,6 +22,7 @@ PROMETHEUS_QUERY_URL: Final[str] = (
 )
 ALERTMANAGER_URL: Final[str] = "http://localhost:9093/api/v2/alerts"
 EXEC_POD: Final[list[str]] = ["kubectl", "exec", "-n", "monitoring", "vmalertmanager-vm-0", "--"]
+MAX_BACKUP_AGE_SECONDS: Final[int] = 30 * 60 * 60
 STALE_BACKUP_SECONDS: Final[int] = 30 * 60
 HIBERNATION_ANNOTATION: Final[str] = "cnpg.io/hibernation"
 COMMAND_TIMEOUT_SECONDS: int = 45
@@ -213,8 +214,15 @@ def cnpg_backups() -> CheckResult:
             None,
         )
         latest_phase = latest.get("status", {}).get("phase", "unknown") if latest else "missing"
-        latest_success_time = latest_success.get("status", {}).get("stoppedAt", "-") if latest_success else "-"
-        details.append(f"{key}: latest={latest_phase}, last_success={latest_success_time}")
+        latest_success_time = latest_success.get("status", {}).get("stoppedAt") if latest_success else None
+        if latest_success_time:
+            latest_success_age = age_seconds(latest_success_time)
+            details.append(
+                f"{key}: latest={latest_phase}, last_success={latest_success_time} "
+                f"(age={latest_success_age / 3600:.1f} hours)"
+            )
+        else:
+            details.append(f"{key}: latest={latest_phase}, last_success=-")
 
         if latest is None:
             bad.append(f"{key}: no Backup resources found")
@@ -227,6 +235,13 @@ def cnpg_backups() -> CheckResult:
                 bad.append(f"{key}: latest backup still started since {started_at}")
         if latest_success is None:
             bad.append(f"{key}: no successful backup found")
+        else:
+            backup_age = age_seconds(latest_success_time)
+            if backup_age > MAX_BACKUP_AGE_SECONDS:
+                bad.append(
+                    f"{key}: last successful backup is {backup_age / 3600:.1f} hours old "
+                    f"(maximum {MAX_BACKUP_AGE_SECONDS / 3600:.0f} hours)"
+                )
 
         archiver = archive_status_from_cluster(namespace, name)
         if archiver.failed:
@@ -237,7 +252,7 @@ def cnpg_backups() -> CheckResult:
         "cnpg-backups",
         "pass" if not bad else "fail",
         "all CNPG backups and WAL archiving healthy" if not bad else f"{len(bad)} CNPG backup/WAL issues",
-        bad or details,
+        bad + details,
     )
 
 

--- a/scripts/cluster-health.py
+++ b/scripts/cluster-health.py
@@ -235,18 +235,21 @@ def cnpg_backups() -> CheckResult:
                 bad.append(f"{key}: latest backup still started since {started_at}")
         if latest_success is None:
             bad.append(f"{key}: no successful backup found")
-        else:
+        elif latest_success_time:
             backup_age = age_seconds(latest_success_time)
             if backup_age > MAX_BACKUP_AGE_SECONDS:
                 bad.append(
                     f"{key}: last successful backup is {backup_age / 3600:.1f} hours old "
                     f"(maximum {MAX_BACKUP_AGE_SECONDS / 3600:.0f} hours)"
                 )
+        else:
+            bad.append(f"{key}: last successful backup has no completion timestamp")
 
         archiver = archive_status_from_cluster(namespace, name)
         if archiver.failed:
             bad.extend(archiver.details)
-        details.extend(archiver.details)
+        else:
+            details.extend(archiver.details)
 
     return CheckResult(
         "cnpg-backups",

--- a/tests/test_cluster_health.py
+++ b/tests/test_cluster_health.py
@@ -78,9 +78,60 @@ class CnpgBackupsTest(unittest.TestCase):
         result = self.run_cnpg_backups([backup], [cluster])
 
         self.assertEqual(result.status, "fail")
-        self.assertEqual(result.details, ["default/app: latest backup failed: backup failed", "default/app: no successful backup found"])
+        self.assertEqual(
+            result.details,
+            [
+                "default/app: latest backup failed: backup failed",
+                "default/app: no successful backup found",
+                "default/app: latest=failed, last_success=-",
+            ],
+        )
 
-    def run_cnpg_backups(self, backups: list[dict], clusters: list[dict]):
+    def test_successful_backup_within_thirty_hours_passes(self) -> None:
+        cluster = {
+            "metadata": {"annotations": {}, "name": "app", "namespace": "default"},
+            "status": {},
+        }
+        backup = self.successful_backup("2026-05-19T09:03:00Z")
+
+        result = self.run_cnpg_backups([backup], [cluster], age_seconds=29 * 60 * 60)
+
+        self.assertEqual(result.status, "pass")
+
+    def test_successful_backup_older_than_thirty_hours_fails(self) -> None:
+        cluster = {
+            "metadata": {"annotations": {}, "name": "app", "namespace": "default"},
+            "status": {},
+        }
+        backup = self.successful_backup("2026-05-19T09:03:00Z")
+
+        result = self.run_cnpg_backups([backup], [cluster], age_seconds=31 * 60 * 60)
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(
+            result.details,
+            [
+                "default/app: last successful backup is 31.0 hours old (maximum 30 hours)",
+                "default/app: latest=completed, last_success=2026-05-19T09:03:00Z (age=31.0 hours)",
+            ],
+        )
+
+    @staticmethod
+    def successful_backup(stopped_at: str) -> dict:
+        return {
+            "metadata": {
+                "creationTimestamp": stopped_at,
+                "namespace": "default",
+            },
+            "spec": {"cluster": {"name": "app"}},
+            "status": {
+                "phase": "completed",
+                "startedAt": stopped_at,
+                "stoppedAt": stopped_at,
+            },
+        }
+
+    def run_cnpg_backups(self, backups: list[dict], clusters: list[dict], age_seconds: float | None = None):
         def kubectl_json(args: list[str]):
             if args == ["get", "backups.postgresql.cnpg.io", "-A"]:
                 return {"items": backups}
@@ -93,6 +144,8 @@ class CnpgBackupsTest(unittest.TestCase):
 
         self.cluster_health.kubectl_json = kubectl_json
         self.cluster_health.archive_status_from_cluster = archive_status_from_cluster
+        if age_seconds is not None:
+            self.cluster_health.age_seconds = lambda timestamp: age_seconds
 
         return self.cluster_health.cnpg_backups()
 

--- a/tests/test_cluster_health.py
+++ b/tests/test_cluster_health.py
@@ -116,6 +116,51 @@ class CnpgBackupsTest(unittest.TestCase):
             ],
         )
 
+    def test_completed_backup_without_stop_time_fails_without_crashing(self) -> None:
+        cluster = {
+            "metadata": {"annotations": {}, "name": "app", "namespace": "default"},
+            "status": {},
+        }
+        backup = self.successful_backup("2026-05-19T09:03:00Z")
+        del backup["status"]["stoppedAt"]
+
+        result = self.run_cnpg_backups([backup], [cluster])
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(
+            result.details,
+            [
+                "default/app: last successful backup has no completion timestamp",
+                "default/app: latest=completed, last_success=-",
+            ],
+        )
+
+    def test_failed_wal_archiving_is_reported_once(self) -> None:
+        cluster = {
+            "metadata": {"annotations": {}, "name": "app", "namespace": "default"},
+            "status": {},
+        }
+        backup = self.successful_backup("2026-05-19T09:03:00Z")
+        archiver = self.cluster_health.CheckResult(
+            "cnpg-wal",
+            "fail",
+            "WAL archiving checked",
+            ["default/app: WAL archiving failing"],
+        )
+
+        result = self.run_cnpg_backups(
+            [backup], [cluster], age_seconds=60, archiver_result=archiver
+        )
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(
+            result.details,
+            [
+                "default/app: WAL archiving failing",
+                "default/app: latest=completed, last_success=2026-05-19T09:03:00Z (age=0.0 hours)",
+            ],
+        )
+
     @staticmethod
     def successful_backup(stopped_at: str) -> dict:
         return {
@@ -131,7 +176,13 @@ class CnpgBackupsTest(unittest.TestCase):
             },
         }
 
-    def run_cnpg_backups(self, backups: list[dict], clusters: list[dict], age_seconds: float | None = None):
+    def run_cnpg_backups(
+        self,
+        backups: list[dict],
+        clusters: list[dict],
+        age_seconds: float | None = None,
+        archiver_result=None,
+    ):
         def kubectl_json(args: list[str]):
             if args == ["get", "backups.postgresql.cnpg.io", "-A"]:
                 return {"items": backups}
@@ -140,6 +191,8 @@ class CnpgBackupsTest(unittest.TestCase):
             raise AssertionError(f"unexpected kubectl args: {args}")
 
         def archive_status_from_cluster(namespace: str, name: str):
+            if archiver_result is not None:
+                return archiver_result
             return self.cluster_health.CheckResult("cnpg-wal", "pass", "WAL archiving checked", [])
 
         self.cluster_health.kubectl_json = kubectl_json


### PR DESCRIPTION
## Summary
- enforce 30-hour CNPG backup freshness in the cluster health task and cover it with tests
- encode med-tracker database credentials in URLs and separate application service accounts from CNPG identities
- treat healthy empty alert queries as OK and exclude the intentional count:up0 recording-rule result from the generic no-data detector

## Verification
- task kubernetes:yayamlls
- task kubernetes:med-tracker-canary-isolation
- python3 tests/test_cluster_health.py
- task kubernetes:cnpg-backups
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-ops/pull/3937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->